### PR TITLE
adds missing explicit conversion to bool of optional

### DIFF
--- a/src/python/py_nonblocking.cpp
+++ b/src/python/py_nonblocking.cpp
@@ -163,10 +163,10 @@ namespace
   {
     check_request_list_not_empty(requests);
     if (py_callable != object())
-      return test_all(requests.begin(), requests.end(), 
-          status_value_iterator(py_callable, requests.begin()));
+      return bool(test_all(requests.begin(), requests.end(), 
+			   status_value_iterator(py_callable, requests.begin())));
     else
-      return test_all(requests.begin(), requests.end());
+      return bool(test_all(requests.begin(), requests.end()));
   }
 
 


### PR DESCRIPTION
Missing explicit conversion to bool caused Boost.MPI to fail to compile
with C++ > 11.

Fixes [trac #10282](https://svn.boost.org/trac/boost/ticket/10282).
