### PR TITLE
Fix #10444: MPI archive failure

### DIFF
--- a/include/boost/mpi/packed_oarchive.hpp
+++ b/include/boost/mpi/packed_oarchive.hpp
@@ -121,12 +121,12 @@ public:
       * this->This() << s;
   }
 
-  void save_override(archive::class_id_type & t, int version){
+  void save_override(const archive::class_id_type & t, int version){
     const boost::int_least16_t x = t;
     * this->This() << x;
   }
 
-  void save_override(archive::version_type & t, int version){
+  void save_override(const archive::version_type & t, int version){
     const boost::int_least8_t x = t;
     * this->This() << x;
   }


### PR DESCRIPTION
Add "const" to save_override for archive::class_id_type and archive::version_type.  WIthout it, they do not participate in overload resolution when called with a const argument, and the default template function is called.  This leads to saving 4 bytes for archive::version_type, but only loading 1 -- all subsequent load operations are then off by 3 bytes.
