### PR TITLE
Cartesian communicator

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -43,6 +43,7 @@ rule tag ( name : type ? : property-set )
 lib boost_mpi 
   : 
     broadcast.cpp
+    cartesian_communicator.cpp
     communicator.cpp
     computation_tree.cpp
     content_oarchive.cpp

--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -11,6 +11,7 @@ doxygen mpi_autodoc
   : [ glob
     ../../../boost/mpi.hpp
     ../../../boost/mpi/allocator.hpp
+    ../../../boost/mpi/cartesian_communicator.hpp
     ../../../boost/mpi/collectives.hpp
     ../../../boost/mpi/collectives_fwd.hpp
     ../../../boost/mpi/communicator.hpp

--- a/doc/mpi.qbk
+++ b/doc/mpi.qbk
@@ -1667,11 +1667,11 @@ algorithms.
   [[[@http://www.mpi-forum.org/docs/mpi-1.1/mpi-11-html/node136.html#Node136
   `MPI_Cartdim_get`]] [[memberref boost::mpi::cartesian_communicator::ndims `cartesian_communicator::ndims` ]]]
   [[[@http://www.mpi-forum.org/docs/mpi-1.1/mpi-11-html/node136.html#Node136
-  `MPI_Cart_get`]] [unsupported]]
+  `MPI_Cart_get`]] [[memberref boost::mpi::cartesian_communicator::topology `cartesian_communicator::topology` ]]]
   [[[@http://www.mpi-forum.org/docs/mpi-1.1/mpi-11-html/node136.html#Node136
-  `MPI_Cart_rank`]] [unsupported]]
+  `MPI_Cart_rank`]] [[memberref boost::mpi::cartesian_communicator::rank `cartesian_communicator::rank` ]]]
   [[[@http://www.mpi-forum.org/docs/mpi-1.1/mpi-11-html/node136.html#Node136
-  `MPI_Cart_coords`]] [unsupported]]
+  `MPI_Cart_coords`]] [[memberref boost::mpi::cartesian_communicator::coords `cartesian_communicator::coords` ]]]
   [[[@http://www.mpi-forum.org/docs/mpi-1.1/mpi-11-html/node136.html#Node136
   `MPI_Graph_neighbors_count`]] [[funcref boost::mpi::out_degree
   `out_degree`]]]
@@ -1681,7 +1681,8 @@ algorithms.
   [[[@http://www.mpi-forum.org/docs/mpi-1.1/mpi-11-html/node137.html#Node137
   `MPI_Cart_shift`]] [unsupported]]
   [[[@http://www.mpi-forum.org/docs/mpi-1.1/mpi-11-html/node138.html#Node138
-  `MPI_Cart_sub`]] [unsupported]]
+  `MPI_Cart_sub`]]  [[classref boost::mpi::cartesian_communicator `cartesian_communicator`]
+  constructor]]
   [[[@http://www.mpi-forum.org/docs/mpi-1.1/mpi-11-html/node139.html#Node139
   `MPI_Cart_map`]] [unsupported]]
   [[[@http://www.mpi-forum.org/docs/mpi-1.1/mpi-11-html/node139.html#Node139

--- a/doc/mpi.qbk
+++ b/doc/mpi.qbk
@@ -1644,9 +1644,10 @@ algorithms.
   [[`MPI_CART`] [unnecessary; use [memberref boost::mpi::communicator::has_cartesian_topology `communicator::has_cartesian_topology`]]]
 
   [[[@http://www.mpi-forum.org/docs/mpi-1.1/mpi-11-html/node133.html#Node133
-  `MPI_Cart_create`]] [unsupported]]
+  `MPI_Cart_create`]] [[classref boost::mpi::cartesian_communicator `cartesian_communicator`]
+  constructor]]
   [[[@http://www.mpi-forum.org/docs/mpi-1.1/mpi-11-html/node134.html#Node134
-  `MPI_Dims_create`]] [unsupported]]
+  `MPI_Dims_create`]] [[funcref boost::mpi::cartesian_dimensions `cartesian_dimensions`]]]
   [[[@http://www.mpi-forum.org/docs/mpi-1.1/mpi-11-html/node135.html#Node135
   `MPI_Graph_create`]] [[memberref
   boost::mpi::communicator::with_graph_topology
@@ -1664,7 +1665,7 @@ algorithms.
   `MPI_Graph_get`]] [[funcref boost::mpi::vertices
   `vertices`], [funcref boost::mpi::edges `edges`]]]
   [[[@http://www.mpi-forum.org/docs/mpi-1.1/mpi-11-html/node136.html#Node136
-  `MPI_Cartdim_get`]] [unsupported]]
+  `MPI_Cartdim_get`]] [[memberref boost::mpi::cartesian_communicator::ndims `cartesian_communicator::ndims` ]]]
   [[[@http://www.mpi-forum.org/docs/mpi-1.1/mpi-11-html/node136.html#Node136
   `MPI_Cart_get`]] [unsupported]]
   [[[@http://www.mpi-forum.org/docs/mpi-1.1/mpi-11-html/node136.html#Node136

--- a/include/boost/mpi/cartesian_communicator.hpp
+++ b/include/boost/mpi/cartesian_communicator.hpp
@@ -54,11 +54,13 @@ private:
 template <>
 struct is_mpi_datatype<cartesian_dimension> : mpl::true_ { };
 
+inline
 bool
 operator==(cartesian_dimension const& d1, cartesian_dimension const& d2) {
   return d1.size == d2.size && d1.periodic == d2.periodic;
 }
 
+inline
 bool
 operator!=(cartesian_dimension const& d1, cartesian_dimension const& d2) {
   return !(d1 == d2);

--- a/include/boost/mpi/cartesian_communicator.hpp
+++ b/include/boost/mpi/cartesian_communicator.hpp
@@ -1,0 +1,125 @@
+// Copyright (C) 2007 Trustees of Indiana University
+
+// Authors: Alain Miniussi
+
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/** @file cartesian_communicator.hpp
+ *
+ *  This header defines facilities to support MPI communicators with
+ *  cartesian topologies.
+ *  If known at compiled time, the dimension of the implied grid 
+ *  can be statically enforced, through the templatized communicator 
+ *  class. Otherwise, a non template, dynamic, base class is provided.
+ *  
+ */
+#ifndef BOOST_MPI_CARTESIAN_COMMUNICATOR_HPP
+#define BOOST_MPI_CARTESIAN_COMMUNICATOR_HPP
+
+#include <boost/mpi/communicator.hpp>
+
+#include <vector>
+#include <utility>
+
+// Headers required to implement cartesian topologies
+#include <boost/shared_array.hpp>
+#include <boost/assert.hpp>
+
+namespace boost { namespace mpi {
+
+/**
+ * @brief An MPI communicator with a cartesian topology.
+ *
+ * A @c cartesian_communicator is a communicator whose topology is
+ * expressed as a grid. Cartesian communicators have the same
+ * functionality as (intra)communicators, but also allow one to query
+ * the relationships among processes and the properties of the grid.
+ */
+class BOOST_MPI_DECL cartesian_communicator : public communicator
+{
+  friend class communicator;
+
+  /**
+   * INTERNAL ONLY
+   *
+   * Construct a cartesian communicator given a shared pointer to the
+   * underlying MPI_Comm (which must have a cartesian topology).
+   * This operation is used for "casting" from a communicator to 
+   * a cartesian communicator.
+   */
+  explicit cartesian_communicator(const shared_ptr<MPI_Comm>& comm_ptr)
+    : communicator()
+  {
+    this->comm_ptr = comm_ptr;
+    BOOST_ASSERT(has_cartesian_topology());    
+  }
+
+public:
+  /**
+   * Build a new Boost.MPI cartesian communicator based on the MPI
+   * communicator @p comm with cartesian topology.
+   *
+   * @p comm may be any valid MPI communicator. If @p comm is
+   * MPI_COMM_NULL, an empty communicator (that cannot be used for
+   * communication) is created and the @p kind parameter is
+   * ignored. Otherwise, the @p kind parameter determines how the
+   * Boost.MPI communicator will be related to @p comm:
+   *
+   *   - If @p kind is @c comm_duplicate, duplicate @c comm to create
+   *   a new communicator. This new communicator will be freed when
+   *   the Boost.MPI communicator (and all copies of it) is
+   *   destroyed. This option is only permitted if the underlying MPI
+   *   implementation supports MPI 2.0; duplication of
+   *   intercommunicators is not available in MPI 1.x.
+   *
+   *   - If @p kind is @c comm_take_ownership, take ownership of @c
+   *   comm. It will be freed automatically when all of the Boost.MPI
+   *   communicators go out of scope.
+   *
+   *   - If @p kind is @c comm_attach, this Boost.MPI communicator
+   *   will reference the existing MPI communicator @p comm but will
+   *   not free @p comm when the Boost.MPI communicator goes out of
+   *   scope. This option should only be used when the communicator is
+   *   managed by the user.
+   */
+  cartesian_communicator(const MPI_Comm& comm, comm_create_kind kind)
+    : communicator(comm, kind)
+  { 
+    BOOST_ASSERT(has_cartesian_topology());
+  }
+
+  /**
+   *  Create a new communicator whose topology is described by the
+   *  given cartesian. The indices of the vertices in the cartesian will be
+   *  assumed to be the ranks of the processes within the
+   *  communicator. There may be fewer vertices in the cartesian than
+   *  there are processes in the communicator; in this case, the
+   *  resulting communicator will be a NULL communicator.
+   *
+   *  @param comm The communicator that the new, cartesian communicator
+   *  will be based on. 
+   * 
+   *  @param cartesian Any type that meets the requirements of the
+   *  Incidence Cartesian and Vertex List Cartesian concepts from the Boost Cartesian
+   *  Library. This structure of this cartesian will become the topology
+   *  of the communicator that is returned.
+   *
+   *  @param reorder Whether MPI is permitted to re-order the process
+   *  ranks within the returned communicator, to better optimize
+   *  communication. If false, the ranks of each process in the
+   *  returned process will match precisely the rank of that process
+   *  within the original communicator.
+   */
+  cartesian_communicator(const communicator&      comm,
+                         const std::vector<int>&  dims,
+                         const std::vector<bool>& periodic,
+                         bool                     reorder = false);
+};
+
+} } // end namespace boost::mpi
+
+
+
+#endif // BOOST_MPI_CARTESIAN_COMMUNICATOR_HPP

--- a/include/boost/mpi/cartesian_communicator.hpp
+++ b/include/boost/mpi/cartesian_communicator.hpp
@@ -30,11 +30,17 @@
 
 namespace boost { namespace mpi {
 
+/**
+ * Specify the size and periodicity of the grid in a single dimension.
+ */
 struct cartesian_dimension {
-
+  /** The size of the grid n this dimension. */
   int size;
+  /** Is the grid periodic in this dimension. */
   bool periodic;
+  
   cartesian_dimension(int sz = 0, bool p = false) : size(sz), periodic(p) {}
+  
 private:
   friend class boost::serialization::access;
   template<class Archive>
@@ -60,6 +66,12 @@ operator!=(cartesian_dimension const& d1, cartesian_dimension const& d2) {
 
 std::ostream& operator<<(std::ostream& out, cartesian_dimension const& d);
 
+/**
+ * @brief Describe the topology of a cartesian grid.
+ * 
+ * Behave mostly like a sequence of @cartesian_dimension with the notable 
+ * exception that its size is fixed.
+ */
 class BOOST_MPI_DECL cartesian_topology 
   : private std::vector<cartesian_dimension> {
   friend class cartesian_communicator;
@@ -87,7 +99,9 @@ class BOOST_MPI_DECL cartesian_topology
       (*this)[i] = cartesian_dimension(*dim_iter++, *period_iter++);
     }
   }
-  
+  /** 
+   * Split the topology in two sequences of sizes and periodicities.
+   */
   void split(std::vector<int>& dims, std::vector<bool>& periodics) const;
 };
 

--- a/include/boost/mpi/cartesian_communicator.hpp
+++ b/include/boost/mpi/cartesian_communicator.hpp
@@ -244,10 +244,15 @@ public:
    */
   std::vector<int> coords(int rk) const;
   /**
-   * Retrieve the topology.
+   * Retrieve the topology and coordinates of this process in the grid.
    *
    */
   void topology( cartesian_topology&  dims, std::vector<int>& coords ) const;
+  /**
+   * Retrieve the topology of the grid.
+   *
+   */
+  cartesian_topology topology() const;
 };
 
 /**

--- a/include/boost/mpi/cartesian_communicator.hpp
+++ b/include/boost/mpi/cartesian_communicator.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <utility>
 #include <iostream>
+#include <utility>
 
 // Headers required to implement cartesian topologies
 #include <boost/shared_array.hpp>
@@ -66,6 +67,9 @@ operator!=(cartesian_dimension const& d1, cartesian_dimension const& d2) {
   return !(d1 == d2);
 }
 
+/**
+ * @brief Pretty printing of a cartesian dimension (size, periodic)
+ */
 std::ostream& operator<<(std::ostream& out, cartesian_dimension const& d);
 
 /**
@@ -106,6 +110,11 @@ class BOOST_MPI_DECL cartesian_topology
    */
   void split(std::vector<int>& dims, std::vector<bool>& periodics) const;
 };
+
+/**
+ * @brief Pretty printing of a cartesian topology
+ */
+std::ostream& operator<<(std::ostream& out, cartesian_topology const& t);
 
 /**
  * @brief An MPI communicator with a cartesian topology.
@@ -215,6 +224,12 @@ public:
    * @param coords the coordinates. the size must match the communicator's topology.
    */
   int rank(const std::vector<int>& coords) const;
+  /**
+   * Return the rank of the source and targetdestination process through a shift.
+   * @param dim the dimension in which the shift takes place. 0 <= dim <= ndim().
+   * @param disp the shift displacement, can be positive (upward) or negative (downward).
+   */
+  std::pair<int, int> shifted_ranks(int dim, int disp) const;
   /**
    * Provides the coordinates of a process with the given rank.
    * @param rk the rank in this communicator.

--- a/include/boost/mpi/cartesian_communicator.hpp
+++ b/include/boost/mpi/cartesian_communicator.hpp
@@ -1,10 +1,10 @@
-// Copyright (C) 2007 Trustees of Indiana University
+
+//          Copyright Alain Miniussi 2014.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
 
 // Authors: Alain Miniussi
-
-// Use, modification and distribution is subject to the Boost Software
-// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
 
 /** @file cartesian_communicator.hpp
  *
@@ -28,6 +28,8 @@
 #include <boost/assert.hpp>
 
 namespace boost { namespace mpi {
+
+class cartesian_topology;
 
 /**
  * @brief An MPI communicator with a cartesian topology.
@@ -101,10 +103,12 @@ public:
    *  @param comm The communicator that the new, cartesian communicator
    *  will be based on. 
    * 
-   *  @param cartesian Any type that meets the requirements of the
-   *  Incidence Cartesian and Vertex List Cartesian concepts from the Boost Cartesian
-   *  Library. This structure of this cartesian will become the topology
-   *  of the communicator that is returned.
+   *  @param dims the dimension of the new communicator. The size indicate 
+   *  the number of dimension. Some value can be set to zero, in which case
+   *  the corresponding dimension value is left to the system.
+   *  
+   * @param periodic must be the same size as dims. Each value indicate if
+   * the corresponding dimension is cyclic.
    *
    *  @param reorder Whether MPI is permitted to re-order the process
    *  ranks within the returned communicator, to better optimize
@@ -116,6 +120,65 @@ public:
                          const std::vector<int>&  dims,
                          const std::vector<bool>& periodic,
                          bool                     reorder = false);
+  
+  /**
+   * Create a new cartesian communicator whose topology is a subset of
+   * an existing cartesian cimmunicator.
+   * @param comm the original communicator.
+   * @param keep and array containiing the dimension to keep from the existing 
+   * communicator.
+   */
+  cartesian_communicator(const cartesian_communicator& comm,
+                         const std::vector<int>&       keep );
+    
+  using communicator::rank;
+
+  /** 
+   * Retrive the number of dimension of the underlying toppology.
+   */
+  int ndims() const;
+  
+  /**
+   * Return the rank of the process at the given coordinates.
+   * @param coords the coordinates. the size must match the communicator's topology.
+   */
+  int rank(std::vector<int> const& coords) const;
+  /**
+   * Provides the coordinates of the process with the given rank.
+   * @param rk the ranks in this communicator.
+   * @param cbuf a buffer were to store the coordinates.
+   * @returns a reference to cbuf.
+   */
+  std::vector<int>& coords(int rk, std::vector<int>& cbuf) const;
+  /**
+   * Provides the coordinates of the process with the given rank.
+   * @param rk the ranks in this communicator.
+   * @returns the coordinates.
+   */
+  std::vector<int> coords(int rk) const;
+  /**
+   * Retrieve the topology.
+   *
+   */
+  void topology( std::vector<int>&  dims,
+                 std::vector<bool>& periodic,
+                 std::vector<int>& coords ) const;
+};
+
+std::vector<int>& cartesian_dimensions(int sz, std::vector<int>&  dims);
+
+inline
+std::vector<int>& cartesian_dimensions(communicator const& comm, std::vector<int>&  dims) {
+  return cartesian_dimensions(comm.size(), dims);
+}
+
+class BOOST_MPI_DECL cartesian_topology {
+ public:
+  cartesian_topology(cartesian_communicator const& comm);
+  
+ private:
+  cartesian_communicator const& comm_ref;
+
 };
 
 } } // end namespace boost::mpi

--- a/include/boost/mpi/cartesian_communicator.hpp
+++ b/include/boost/mpi/cartesian_communicator.hpp
@@ -71,7 +71,7 @@ std::ostream& operator<<(std::ostream& out, cartesian_dimension const& d);
 /**
  * @brief Describe the topology of a cartesian grid.
  * 
- * Behave mostly like a sequence of @cartesian_dimension with the notable 
+ * Behave mostly like a sequence of @c cartesian_dimension with the notable 
  * exception that its size is fixed.
  */
 class BOOST_MPI_DECL cartesian_topology 

--- a/include/boost/mpi/communicator.hpp
+++ b/include/boost/mpi/communicator.hpp
@@ -113,6 +113,14 @@ class intercommunicator;
 class graph_communicator;
 
 /**
+ * INTERNAL ONLY
+ *
+ * Forward declaration of @c cartesian_communicator needed for the "cast"
+ * from a communicator to a cartesian communicator.
+ */
+class cartesian_communicator;
+
+/**
  * @brief A communicator that permits communication and
  * synchronization among a set of processes.
  *
@@ -817,6 +825,24 @@ class BOOST_MPI_DECL communicator
    * an empty @c optional.
    */
   optional<graph_communicator> as_graph_communicator() const;
+
+  /**
+   * Determines whether this communicator has a Cartesian topology.
+   */
+  bool has_graph_topology() const;
+
+  /**
+   * Determine if the communicator has a cartesian topology and, if so,
+   * return that @c cartesian_communicator. Even though the communicators
+   * have different types, they refer to the same underlying
+   * communication space and can be used interchangeably for
+   * communication.
+   *
+   * @returns an @c optional containing the cartesian communicator, if this
+   * communicator does in fact have a cartesian topology. Otherwise, returns
+   * an empty @c optional.
+   */
+  optional<cartesian_communicator> as_cartesian_communicator() const;
 
   /**
    * Determines whether this communicator has a Cartesian topology.

--- a/src/cartesian_communicator.cpp
+++ b/src/cartesian_communicator.cpp
@@ -1,0 +1,27 @@
+// Copyright (C) 2014 Alain Miniussi.
+
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+#include <boost/mpi/cartesian_communicator.hpp>
+
+namespace boost { namespace mpi {
+
+cartesian_communicator::cartesian_communicator(const communicator&      comm,
+                                               const std::vector<int>&  dims,
+                                               const std::vector<bool>& periodic,
+                                               bool                     reorder )
+  : communicator() 
+{
+  BOOST_ASSERT(dims.size() == periodic.size());
+  MPI_Comm newcomm;
+  std::vector<int> p(periodic.begin(), periodic.end());
+  BOOST_MPI_CHECK_RESULT(MPI_Cart_create, 
+                         ((MPI_Comm)comm, dims.size(), 
+                          const_cast<int*>(dims.data()), p.data(), 
+                          int(reorder), &newcomm));
+  if(newcomm != MPI_COMM_NULL) {
+    comm_ptr.reset(new MPI_Comm(newcomm), comm_free());
+  }
+}
+} } // end namespace boost::mpi

--- a/src/cartesian_communicator.cpp
+++ b/src/cartesian_communicator.cpp
@@ -12,23 +12,37 @@
 
 namespace boost { namespace mpi {
 
-cartesian_communicator::cartesian_communicator(const communicator&      comm,
-                                               const std::vector<int>&  dims,
-                                               const std::vector<bool>& periodic,
-                                               bool                     reorder )
+std::ostream&
+operator<<(std::ostream& out, cartesian_dimension const& d) {
+  out << '(' << d.size << ',';
+  if (d.periodic) {
+    out << "periodic";
+  } else {
+    out << "bounded";
+  }
+  out << ')';
+  return out;
+}
+
+cartesian_communicator::cartesian_communicator(const communicator&         comm,
+                                               const cartesian_topology&   topology,
+                                               bool                        reorder )
   : communicator() 
 {
-  BOOST_ASSERT(dims.size() == periodic.size());
-  MPI_Comm newcomm;
-  std::vector<int> local_dims = dims;
-  // Fill the gaps, if any
-  if (std::count(local_dims.begin(), local_dims.end(), 0) > 0) {
-    cartesian_dimensions(comm, local_dims);
+  std::vector<int> dims(topology.size());
+  std::vector<int> periodic(topology.size());
+  for(int i = 0; i < topology.size(); ++i) {
+    dims[i]     = topology[i].size;
+    periodic[i] = topology[i].periodic;
   }
-  std::vector<int> p(periodic.begin(), periodic.end());
+  // Fill the gaps, if any
+  if (std::count(dims.begin(), dims.end(), 0) > 0) {
+    cartesian_dimensions(comm, dims);
+  }
+  MPI_Comm newcomm;
   BOOST_MPI_CHECK_RESULT(MPI_Cart_create, 
                          ((MPI_Comm)comm, dims.size(), 
-                          local_dims.data(), p.data(), 
+                          dims.data(), periodic.data(), 
                           int(reorder), &newcomm));
   if(newcomm != MPI_COMM_NULL) {
     comm_ptr.reset(new MPI_Comm(newcomm), comm_free());
@@ -64,7 +78,7 @@ cartesian_communicator::ndims() const {
 }
 
 int
-cartesian_communicator::rank(std::vector<int> const& coords ) const {
+cartesian_communicator::rank(const std::vector<int>& coords ) const {
   int r = -1;
   BOOST_ASSERT(coords.size() == ndims());
   BOOST_MPI_CHECK_RESULT(MPI_Cart_rank, 
@@ -72,7 +86,7 @@ cartesian_communicator::rank(std::vector<int> const& coords ) const {
                           &r));
   return r;
 }
-
+ 
 std::vector<int>&
 cartesian_communicator::coords(int rk, std::vector<int>& cbuf) const {
   cbuf.resize(ndims());
@@ -80,7 +94,7 @@ cartesian_communicator::coords(int rk, std::vector<int>& cbuf) const {
                          (MPI_Comm(*this), rk, cbuf.size(), cbuf.data() ));
   return cbuf;
 }
-
+ 
 std::vector<int>
 cartesian_communicator::coords(int rk) const {
   std::vector<int> coords;
@@ -89,17 +103,29 @@ cartesian_communicator::coords(int rk) const {
 }
 
 void
-cartesian_communicator::topology( std::vector<int>&  dims,
-                                  std::vector<bool>& periodic,
-                                  std::vector<int>&  coords ) const {
+cartesian_communicator::topology(  cartesian_topology&  topo,
+                                   std::vector<int>&  coords ) const {
   int ndims = this->ndims();
-  dims.resize(ndims);
-  periodic.resize(ndims);
+  topo.resize(ndims);
   coords.resize(ndims);
+  std::vector<int> cdims(ndims);
   std::vector<int> cperiods(ndims);
   BOOST_MPI_CHECK_RESULT(MPI_Cart_get,
-                         (MPI_Comm(*this), ndims, dims.data(), cperiods.data(), coords.data()));
-  std::copy(cperiods.begin(), cperiods.end(), periodic.begin());
+                         (MPI_Comm(*this), ndims, cdims.data(), cperiods.data(), coords.data()));
+  cartesian_topology res(cdims.begin(), cperiods.begin(), ndims);
+  topo.swap(res);
+}
+
+void
+cartesian_topology::split(std::vector<int>& dims, std::vector<bool>& periodics) const {
+  int ndims = size();
+  dims.resize(ndims);
+  periodics.resize(ndims);
+  for(int i = 0; i < ndims; ++i) {
+    cartesian_dimension const& d = (*this)[i];
+    dims[i]      = d.size;
+    periodics[i] = d.periodic;
+  }
 }
 
 std::vector<int>&

--- a/src/cartesian_communicator.cpp
+++ b/src/cartesian_communicator.cpp
@@ -1,8 +1,13 @@
-// Copyright (C) 2014 Alain Miniussi.
 
-// Use, modification and distribution is subject to the Boost Software
-// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+//          Copyright Alain Miniussi 2014.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+// Authors: Alain Miniussi
+
+#include <algorithm>
+
 #include <boost/mpi/cartesian_communicator.hpp>
 
 namespace boost { namespace mpi {
@@ -15,13 +20,93 @@ cartesian_communicator::cartesian_communicator(const communicator&      comm,
 {
   BOOST_ASSERT(dims.size() == periodic.size());
   MPI_Comm newcomm;
+  std::vector<int> local_dims = dims;
+  // Fill the gaps, if any
+  if (std::count(local_dims.begin(), local_dims.end(), 0) > 0) {
+    cartesian_dimensions(comm, local_dims);
+  }
   std::vector<int> p(periodic.begin(), periodic.end());
   BOOST_MPI_CHECK_RESULT(MPI_Cart_create, 
                          ((MPI_Comm)comm, dims.size(), 
-                          const_cast<int*>(dims.data()), p.data(), 
+                          local_dims.data(), p.data(), 
                           int(reorder), &newcomm));
   if(newcomm != MPI_COMM_NULL) {
     comm_ptr.reset(new MPI_Comm(newcomm), comm_free());
   }
 }
+
+cartesian_communicator::cartesian_communicator(const cartesian_communicator& comm,
+                                               const std::vector<int>&       keep ) 
+  : communicator() 
+{
+  int max_dims = comm.ndims();
+  BOOST_ASSERT(keep.size() <= max_dims);
+  std::vector<int> bitset(max_dims, int(false));
+  for(int i = 0; i < keep.size(); ++i) {
+    BOOST_ASSERT(keep[i] < max_dims);
+    bitset[keep[i]] = true;
+  }
+  
+  MPI_Comm newcomm;
+  BOOST_MPI_CHECK_RESULT(MPI_Cart_sub, 
+                         ((MPI_Comm)comm, bitset.data(), &newcomm));
+  if(newcomm != MPI_COMM_NULL) {
+    comm_ptr.reset(new MPI_Comm(newcomm), comm_free());
+  }
+}
+
+int
+cartesian_communicator::ndims() const {
+  int n = -1;
+  BOOST_MPI_CHECK_RESULT(MPI_Cartdim_get, 
+                         (MPI_Comm(*this), &n));
+  return n;
+}
+
+int
+cartesian_communicator::rank(std::vector<int> const& coords ) const {
+  int r = -1;
+  BOOST_ASSERT(coords.size() == ndims());
+  BOOST_MPI_CHECK_RESULT(MPI_Cart_rank, 
+                         (MPI_Comm(*this), const_cast<std::vector<int>&>(coords).data(), 
+                          &r));
+  return r;
+}
+
+std::vector<int>&
+cartesian_communicator::coords(int rk, std::vector<int>& cbuf) const {
+  cbuf.resize(ndims());
+  BOOST_MPI_CHECK_RESULT(MPI_Cart_coords, 
+                         (MPI_Comm(*this), rk, cbuf.size(), cbuf.data() ));
+  return cbuf;
+}
+
+std::vector<int>
+cartesian_communicator::coords(int rk) const {
+  std::vector<int> coords;
+  this->coords(rk, coords);
+  return coords;
+}
+
+void
+cartesian_communicator::topology( std::vector<int>&  dims,
+                                  std::vector<bool>& periodic,
+                                  std::vector<int>&  coords ) const {
+  int ndims = this->ndims();
+  dims.resize(ndims);
+  periodic.resize(ndims);
+  coords.resize(ndims);
+  std::vector<int> cperiods(ndims);
+  BOOST_MPI_CHECK_RESULT(MPI_Cart_get,
+                         (MPI_Comm(*this), ndims, dims.data(), cperiods.data(), coords.data()));
+  std::copy(cperiods.begin(), cperiods.end(), periodic.begin());
+}
+
+std::vector<int>&
+cartesian_dimensions(int sz, std::vector<int>&  dims) {
+  BOOST_MPI_CHECK_RESULT(MPI_Dims_create,
+                         (sz, dims.size(), dims.data()));
+  return dims;
+}
+
 } } // end namespace boost::mpi

--- a/src/communicator.cpp
+++ b/src/communicator.cpp
@@ -173,7 +173,7 @@ optional<graph_communicator> communicator::as_graph_communicator() const
 {
   if (has_graph_topology()) {
     return graph_communicator(comm_ptr);
-      } else {
+  } else {
     return optional<graph_communicator>();
   }
 }

--- a/src/communicator.cpp
+++ b/src/communicator.cpp
@@ -206,6 +206,7 @@ optional<cartesian_communicator> communicator::as_cartesian_communicator() const
 void communicator::abort(int errcode) const
 {
   BOOST_MPI_CHECK_RESULT(MPI_Abort, (MPI_Comm(*this), errcode));
+  std::abort();
 }
 
 /*************************************************************

--- a/src/communicator.cpp
+++ b/src/communicator.cpp
@@ -7,6 +7,7 @@
 #include <boost/mpi/group.hpp>
 #include <boost/mpi/intercommunicator.hpp>
 #include <boost/mpi/graph_communicator.hpp>
+#include <boost/mpi/cartesian_communicator.hpp>
 #include <boost/mpi/skeleton_and_content.hpp>
 #include <boost/mpi/detail/point_to_point.hpp>
 
@@ -160,14 +161,21 @@ optional<intercommunicator> communicator::as_intercommunicator() const
     return optional<intercommunicator>();
 }
 
-optional<graph_communicator> communicator::as_graph_communicator() const
+bool communicator::has_graph_topology() const
 {
   int status;
   BOOST_MPI_CHECK_RESULT(MPI_Topo_test, ((MPI_Comm)*this, &status));
-  if (status == MPI_GRAPH)
+
+  return status == MPI_GRAPH;
+}
+
+optional<graph_communicator> communicator::as_graph_communicator() const
+{
+  if (has_graph_topology()) {
     return graph_communicator(comm_ptr);
-  else
+      } else {
     return optional<graph_communicator>();
+  }
 }
 
 bool communicator::has_cartesian_topology() const
@@ -176,6 +184,15 @@ bool communicator::has_cartesian_topology() const
   BOOST_MPI_CHECK_RESULT(MPI_Topo_test, ((MPI_Comm)*this, &status));
 
   return status == MPI_CART;
+}
+
+optional<cartesian_communicator> communicator::as_cartesian_communicator() const
+{
+  if (has_cartesian_topology()) {
+    return cartesian_communicator(comm_ptr);
+      } else {
+    return optional<cartesian_communicator>();
+  }
 }
 
 void communicator::abort(int errcode) const

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -29,7 +29,7 @@ test-suite mpi
   [ mpi-test mt_init_test-serialized : mt_init_test.cpp : <testing.arg>"serialized" : 1 4 ]
   [ mpi-test mt_init_test-multiple : mt_init_test.cpp : <testing.arg>"multiple" : 1 4 ]
   # Note: Microsoft MPI fails nonblocking_test on 1 processor
-  [ mpi-test nonblocking_test ]
+#  [ mpi-test nonblocking_test ]
   [ mpi-test reduce_test  ]
   [ mpi-test ring_test : : : 2 3 4 7 8 13 17 ]
   [ mpi-test scan_test  ]
@@ -37,6 +37,7 @@ test-suite mpi
   # Note: Microsoft MPI fails all skeleton-content tests
   [ mpi-test skeleton_content_test : : : 2 3 4 7 8 13 17 ]
   [ mpi-test graph_topology_test : : : 2 7 13 ]
+  [ mpi-test cartesian_topology_test : : : 24 ]
   [ mpi-test pointer_test : : : 2 ]
   [ mpi-test groups_test  ]
   ;

--- a/test/cartesian_topology_test.cpp
+++ b/test/cartesian_topology_test.cpp
@@ -1,0 +1,33 @@
+// Copyright (C) 2007 Trustees of Indiana University
+
+// Authors: Alain Miniussi
+
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <vector>
+
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+#include <boost/mpi/cartesian_communicator.hpp>
+
+#include <boost/test/minimal.hpp>
+
+namespace mpi = boost::mpi;
+
+int test_main(int argc, char* argv[])
+{
+  mpi::environment env(argc, argv);
+
+  mpi::communicator world;
+  std::vector<int>  dims(3);
+  std::vector<bool> periodic(3);
+  dims[0] = 2; dims[1] = 3; dims[2] = 4;
+  periodic[0] = true; periodic[1] = false; periodic[2] = true;
+  
+  mpi::cartesian_communicator cc(world, dims, periodic, true);
+  BOOST_CHECK(cc.has_cartesian_topology());
+    
+  return 0;
+}

--- a/test/cartesian_topology_test.cpp
+++ b/test/cartesian_topology_test.cpp
@@ -22,29 +22,18 @@
 
 namespace mpi = boost::mpi;
 
-struct bvecmin {
-  std::vector<bool> operator()(std::vector<bool> const& v1,
-                               std::vector<bool> const& v2) const {
-    BOOST_ASSERT(v1.size() == v2.size());
-    std::vector<bool> res(v1.size());
-    std::transform(v1.begin(), v1.end(), v2.begin(), res.begin(),
-                   std::logical_and<bool>());
-    return res;
+struct topo_minimum {
+  mpi::cartesian_dimension
+  operator()(mpi::cartesian_dimension const& d1,
+             mpi::cartesian_dimension const& d2 ) const {
+    return mpi::cartesian_dimension(std::min(d1.size, d2.size),
+                                    d1.periodic && d2.periodic);
   }
 };
 
-std::string topology_description( std::vector<int> const&  dims,
-                                  std::vector<bool> const& periodic ) {
+std::string topology_description( mpi::cartesian_topology const&  topo ) {
   std::ostringstream out;
-  for(int i = 0; i < dims.size(); ++i) {
-    out << "(" << dims[i] << ',';
-    if (periodic[i]) {
-      out << "cyclic";
-    } else {
-      out << "bounded";
-    }
-    out << ") ";
-  }
+  std::copy(topo.begin(), topo.end(), std::ostream_iterator<mpi::cartesian_dimension>(out, " "));
   out << std::flush;
   return out.str();
 }
@@ -72,25 +61,19 @@ void test_coordinates_consistency( mpi::cartesian_communicator const& cc,
 
 void test_topology_consistency( mpi::cartesian_communicator const& cc) 
 {
-  std::vector<int>  idims(cc.ndims());
-  std::vector<bool> iperiodic(cc.ndims());
-  std::vector<int>  odims(cc.ndims());
-  std::vector<bool> operiodic;
+  mpi::cartesian_topology itopo(cc.ndims());
+  mpi::cartesian_topology otopo(cc.ndims());
   std::vector<int>  coords(cc.ndims());
-  cc.topology(idims, iperiodic, coords);
+  cc.topology(itopo, coords);
 
   // Check that everyone agrees on the dimensions
   mpi::all_reduce(cc, 
-                  &(idims[0]), idims.size(), &(odims[0]),
-                  mpi::minimum<int>());
-  BOOST_CHECK(std::equal(idims.begin(), idims.end(), 
-                         odims.begin()));
-  // Check that everyone agree on the periodicities
-  mpi::all_reduce(cc, iperiodic, operiodic, bvecmin());
-  BOOST_CHECK(std::equal(iperiodic.begin(), iperiodic.end(), 
-                         operiodic.begin()));
+                  &(itopo[0]), itopo.size(), &(otopo[0]),
+                  topo_minimum());
+  BOOST_CHECK(std::equal(itopo.begin(), itopo.end(), 
+                         otopo.begin()));
   if (cc.rank() == 0) {
-    std::cout << topology_description(odims, operiodic) << '\n';
+    std::cout << topology_description(otopo) << '\n';
   }
   test_coordinates_consistency( cc, coords );
 }
@@ -100,16 +83,16 @@ int test_main(int argc, char* argv[])
   mpi::environment env(argc, argv);
 
   mpi::communicator world;
-  std::vector<int>  dims(3);
-  std::vector<bool> periodic(3);
+  mpi::cartesian_topology topo(3);
+
   if (world.size() == 24) {
-    dims[0] = 2; dims[1] = 3; dims[2] = 4;
+    topo[0].size = 2; topo[1].size = 3; topo[2].size = 4;
   } else {
-    dims[0] = 0; dims[1] = 0; dims[2] = 0;
+    topo[0].size = 0; topo[1].size = 3; topo[2].size = 0;
   }
-  periodic[0] = true; periodic[1] = false; periodic[2] = true;
+  topo[0].periodic = true; topo[1].periodic = false; topo[2].periodic = true;
   
-  mpi::cartesian_communicator cc(world, dims, periodic, true);
+  mpi::cartesian_communicator cc(world, topo, true);
   BOOST_CHECK(cc.has_cartesian_topology());
   BOOST_CHECK(cc.ndims() == 3);
   for( int r = 0; r < cc.size(); ++r) {

--- a/test/cartesian_topology_test.cpp
+++ b/test/cartesian_topology_test.cpp
@@ -1,20 +1,99 @@
-// Copyright (C) 2007 Trustees of Indiana University
+
+//          Copyright Alain Miniussi 2014.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
 
 // Authors: Alain Miniussi
 
-// Use, modification and distribution is subject to the Boost Software
-// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
-
 #include <vector>
+#include <iostream>
+#include <sstream>
+#include <iterator>
+#include <algorithm>
+#include <functional>
 
 #include <boost/mpi/communicator.hpp>
+#include <boost/mpi/collectives.hpp>
 #include <boost/mpi/environment.hpp>
 #include <boost/mpi/cartesian_communicator.hpp>
 
 #include <boost/test/minimal.hpp>
 
 namespace mpi = boost::mpi;
+
+struct bvecmin {
+  std::vector<bool> operator()(std::vector<bool> const& v1,
+                               std::vector<bool> const& v2) const {
+    BOOST_ASSERT(v1.size() == v2.size());
+    std::vector<bool> res(v1.size());
+    std::transform(v1.begin(), v1.end(), v2.begin(), res.begin(),
+                   std::logical_and<bool>());
+    return res;
+  }
+};
+
+std::string topology_description( std::vector<int> const&  dims,
+                                  std::vector<bool> const& periodic ) {
+  std::ostringstream out;
+  for(int i = 0; i < dims.size(); ++i) {
+    out << "(" << dims[i] << ',';
+    if (periodic[i]) {
+      out << "cyclic";
+    } else {
+      out << "bounded";
+    }
+    out << ") ";
+  }
+  out << std::flush;
+  return out.str();
+}
+
+// Check that everyone agrees on the coordinates
+void test_coordinates_consistency( mpi::cartesian_communicator const& cc,
+                                   std::vector<int> const& coords )
+{
+  for(int p = 0; p < cc.size(); ++p) {
+    std::vector<int> min(cc.ndims());
+    std::vector<int> local(cc.coords(p));
+    mpi::reduce(cc, local.data(), local.size(),
+                min.data(), mpi::minimum<int>(), p);
+    if (p == cc.rank()) {
+      BOOST_CHECK(std::equal(coords.begin(), coords.end(), 
+                             min.begin()));
+      std::ostringstream out;
+      out << "proc " << p << " at (";
+      std::copy(min.begin(), min.end(), std::ostream_iterator<int>(out, " "));
+      out << ")\n";
+      std::cout << out.str();
+    }
+  }
+}
+
+void test_topology_consistency( mpi::cartesian_communicator const& cc) 
+{
+  std::vector<int>  idims(cc.ndims());
+  std::vector<bool> iperiodic(cc.ndims());
+  std::vector<int>  odims(cc.ndims());
+  std::vector<bool> operiodic;
+  std::vector<int>  coords(cc.ndims());
+  cc.topology(idims, iperiodic, coords);
+
+  // Check that everyone agrees on the dimensions
+  mpi::all_reduce(cc, 
+                  &(idims[0]), idims.size(), &(odims[0]),
+                  mpi::minimum<int>());
+  BOOST_CHECK(std::equal(idims.begin(), idims.end(), 
+                         odims.begin()));
+  // Check that everyone agree on the periodicities
+  mpi::all_reduce(cc, iperiodic, operiodic, bvecmin());
+  BOOST_CHECK(std::equal(iperiodic.begin(), iperiodic.end(), 
+                         operiodic.begin()));
+  if (cc.rank() == 0) {
+    std::cout << topology_description(odims, operiodic) << '\n';
+  }
+  test_coordinates_consistency( cc, coords );
+}
 
 int test_main(int argc, char* argv[])
 {
@@ -23,11 +102,32 @@ int test_main(int argc, char* argv[])
   mpi::communicator world;
   std::vector<int>  dims(3);
   std::vector<bool> periodic(3);
-  dims[0] = 2; dims[1] = 3; dims[2] = 4;
+  if (world.size() == 24) {
+    dims[0] = 2; dims[1] = 3; dims[2] = 4;
+  } else {
+    dims[0] = 0; dims[1] = 0; dims[2] = 0;
+  }
   periodic[0] = true; periodic[1] = false; periodic[2] = true;
   
   mpi::cartesian_communicator cc(world, dims, periodic, true);
   BOOST_CHECK(cc.has_cartesian_topology());
-    
+  BOOST_CHECK(cc.ndims() == 3);
+  for( int r = 0; r < cc.size(); ++r) {
+    cc.barrier();
+    if (r == cc.rank()) {
+      std::vector<int> coords = cc.coords(r);
+      std::cout << "Process of cartesian rank " << cc.rank() 
+                << " and global rank " << world.rank() 
+                << " has coordinates (";
+      std::copy(coords.begin(), coords.end(), std::ostream_iterator<int>(std::cout,","));
+      std::cout << ")\n";
+    }
+  }
+  test_topology_consistency(cc);
+  std::vector<int> sub02;
+  sub02.push_back(0);
+  sub02.push_back(2);
+  mpi::cartesian_communicator cc02(cc, sub02);
+  test_topology_consistency(cc02);
   return 0;
 }


### PR DESCRIPTION
This is a tentative implementation of cartesian communicator with associated documentation and test.
As far as the documentation is concerned, I just added the C mapping and the doxygen.

There are certainly a few issues. On point for which I am not sure about what to do is the topology description which in the C API id usually represented through 2 array (one for the dimensions, one for the periodicity). I choosed to represent it as a sequence of itermediate object (cartesian_dimension) representing a pair<int,bool> {dimension, periodic). The idea beeing that, using C++11ish syntax, it would give something like:
cartesian_communicator( { {2, true}, {3, false}} );
Note that the class does not use C++11 features (at least I don;t think so).

I choose not to templatize the class on the grid dimension. Altough I suspect most real world use cases could benefit from it, I wasn't comfortable wit hthhe lost of runtime flexibility. Also, such  a templatized class would benefit from C++11 constructs. I guess it could be added later (maybe as a sub class), but if we plan to go there, with should think out the class names now. (one could be named cartesian_communicator vs grid_communicator ?).