### PR TITLE
upgrade MPI 1.1 stuff to MPI 2.x stuff

### DIFF
--- a/src/communicator.cpp
+++ b/src/communicator.cpp
@@ -43,7 +43,7 @@ communicator::communicator(const MPI_Comm& comm, comm_create_kind kind)
       MPI_Comm newcomm;
       BOOST_MPI_CHECK_RESULT(MPI_Comm_dup, (comm, &newcomm));
       comm_ptr.reset(new MPI_Comm(newcomm), comm_free());
-      MPI_Errhandler_set(newcomm, MPI_ERRORS_RETURN);
+      MPI_Comm_set_errhandler(newcomm, MPI_ERRORS_RETURN);
       break;
     }
 

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -13,7 +13,7 @@ bool timer::time_is_global()
   int* is_global;
   int found = 0;
 
-  BOOST_MPI_CHECK_RESULT(MPI_Attr_get,
+  BOOST_MPI_CHECK_RESULT(MPI_Comm_get_attr,
                          (MPI_COMM_WORLD, MPI_WTIME_IS_GLOBAL, &is_global,
                           &found));
   if (!found)


### PR DESCRIPTION
The version 3 of the MPI standard is out now. So we probably should upgraded really old (1.1) API to 2.x.
