### PR TITLE
Fix: adapt to renaming of serialization::array_wrapper

### DIFF
--- a/include/boost/mpi/communicator.hpp
+++ b/include/boost/mpi/communicator.hpp
@@ -1257,7 +1257,7 @@ communicator::array_recv_impl(int source, int tag, T* values, int n,
   ia >> count;
 
   // Deserialize the data in the message
-  boost::serialization::array<T> arr(values, count > n? n : count);
+  boost::serialization::array_wrapper<T> arr(values, count > n? n : count);
   ia >> arr;
 
   if (count > n) {
@@ -1459,7 +1459,7 @@ namespace detail {
     ia >> count;
     
     // Deserialize the data in the message
-    boost::serialization::array<T> arr(values, count > n? n : count);
+    boost::serialization::array_wrapper<T> arr(values, count > n? n : count);
     ia >> arr;
     
     if (count > n) {

--- a/include/boost/mpi/detail/binary_buffer_iprimitive.hpp
+++ b/include/boost/mpi/detail/binary_buffer_iprimitive.hpp
@@ -66,7 +66,7 @@ public:
 
     // fast saving of arrays of fundamental types
     template<class T>
-    void load_array(serialization::array<T> const& x, unsigned int /* file_version */)
+    void load_array(serialization::array_wrapper<T> const& x, unsigned int /* file_version */)
     {
       BOOST_MPL_ASSERT((serialization::is_bitwise_serializable<BOOST_DEDUCED_TYPENAME remove_const<T>::type>));
       if (x.count())
@@ -76,7 +76,7 @@ public:
     typedef serialization::is_bitwise_serializable<mpl::_1> use_array_optimization;
 
     template<class T>
-    void load(serialization::array<T> const& x)
+    void load(serialization::array_wrapper<T> const& x)
     {
       load_array(x,0u);
     }

--- a/include/boost/mpi/detail/binary_buffer_oprimitive.hpp
+++ b/include/boost/mpi/detail/binary_buffer_oprimitive.hpp
@@ -55,7 +55,7 @@ public:
 
     // fast saving of arrays
     template<class T>
-    void save_array(serialization::array<T> const& x, unsigned int /* file_version */)
+    void save_array(serialization::array_wrapper<T> const& x, unsigned int /* file_version */)
     {
     
       BOOST_MPL_ASSERT((serialization::is_bitwise_serializable<BOOST_DEDUCED_TYPENAME remove_const<T>::type>));
@@ -64,7 +64,7 @@ public:
     }
 
     template<class T>
-    void save(serialization::array<T> const& x)
+    void save(serialization::array_wrapper<T> const& x)
     {
       save_array(x,0u);
     }

--- a/include/boost/mpi/detail/forward_iprimitive.hpp
+++ b/include/boost/mpi/detail/forward_iprimitive.hpp
@@ -42,7 +42,7 @@ public:
     
     /// loading of arrays is forwarded to the implementation archive
     template<class T>
-    void load_array(serialization::array<T> & x, unsigned int file_version )
+    void load_array(serialization::array_wrappe<T> & x, unsigned int file_version )
     {
       implementation_archive.load_array(x,file_version);
     }

--- a/include/boost/mpi/detail/forward_oprimitive.hpp
+++ b/include/boost/mpi/detail/forward_oprimitive.hpp
@@ -43,7 +43,7 @@ public:
     
     /// saving of arrays is forwarded to the implementation archive
     template<class T>
-    void save_array(serialization::array<T> const& x, unsigned int file_version )
+    void save_array(serialization::array_wrapper<T> const& x, unsigned int file_version )
     {
       implementation_archive.save_array(x,file_version);
     }

--- a/include/boost/mpi/detail/ignore_iprimitive.hpp
+++ b/include/boost/mpi/detail/ignore_iprimitive.hpp
@@ -37,7 +37,7 @@ public:
 
         /// don't do anything when loading arrays
     template<class T>
-    void load_array(serialization::array<T> &, unsigned int )
+    void load_array(serialization::array_wrapper<T> &, unsigned int )
     {}
 
     typedef is_mpi_datatype<mpl::_1> use_array_optimization;

--- a/include/boost/mpi/detail/ignore_oprimitive.hpp
+++ b/include/boost/mpi/detail/ignore_oprimitive.hpp
@@ -36,7 +36,7 @@ public:
 
         /// don't do anything when saving arrays
     template<class T>
-    void save_array(serialization::array<T> const&, unsigned int )
+    void save_array(serialization::array_wrapper<T> const&, unsigned int )
     {
     }
 

--- a/include/boost/mpi/detail/mpi_datatype_primitive.hpp
+++ b/include/boost/mpi/detail/mpi_datatype_primitive.hpp
@@ -63,7 +63,7 @@ public:
 
     // fast saving of arrays of MPI types
     template<class T>
-    void save_array(serialization::array<T> const& x, unsigned int /* version */)
+    void save_array(serialization::array_wrapper<T> const& x, unsigned int /* version */)
     {
       if (x.count())
         save_impl(x.address(), boost::mpi::get_mpi_datatype(*x.address()), x.count());

--- a/include/boost/mpi/detail/packed_iprimitive.hpp
+++ b/include/boost/mpi/detail/packed_iprimitive.hpp
@@ -64,7 +64,7 @@ public:
 
     // fast saving of arrays of fundamental types
     template<class T>
-    void load_array(serialization::array<T> const& x, unsigned int /* file_version */)
+    void load_array(serialization::array_wrapper<T> const& x, unsigned int /* file_version */)
     {
       if (x.count())
         load_impl(x.address(), get_mpi_datatype(*x.address()), x.count());
@@ -72,7 +72,7 @@ public:
 
 /*
     template<class T>
-    void load(serialization::array<T> const& x)
+    void load(serialization::array_wrapper<T> const& x)
     {
       load_array(x,0u);
     }

--- a/include/boost/mpi/detail/packed_oprimitive.hpp
+++ b/include/boost/mpi/detail/packed_oprimitive.hpp
@@ -54,7 +54,7 @@ public:
 
     // fast saving of arrays
     template<class T>
-    void save_array(serialization::array<T> const& x, unsigned int /* file_version */)
+    void save_array(serialization::array_wrapper<T> const& x, unsigned int /* file_version */)
     {
         if (x.count())
           save_impl(x.address(), get_mpi_datatype(*x.address()), x.count());


### PR DESCRIPTION
Commit e3b67eb299b070edb32c2eb5da76653b4ed9cf5e in Boost.Serialization
renames serialization::array to serialization::array_wrapper.