### PR TITLE
Fix incorrect usage of auto_ptr to free an array

### DIFF
--- a/include/boost/mpi/python/serialize.hpp
+++ b/include/boost/mpi/python/serialize.hpp
@@ -26,7 +26,6 @@
 #include <boost/python/str.hpp>
 #include <boost/python/extract.hpp>
 
-#include <memory>
 #include <map>
 
 #include <boost/function/function3.hpp>
@@ -36,6 +35,8 @@
 
 #include <boost/serialization/split_free.hpp>
 #include <boost/serialization/array.hpp>
+
+#include <boost/smart_ptr/scoped_array.hpp>
 
 #include <boost/assert.hpp>
 
@@ -441,7 +442,7 @@ load_impl(Archiver& ar, boost::python::object& obj,
   int len;
   ar >> len;
 
-  std::auto_ptr<char> string(new char[len]);
+  boost::scoped_array<char> string(new char[len]);
   ar >> boost::serialization::make_array(string.get(), len);
   boost::python::str py_string(string.get(), len);
   obj = boost::python::pickle::loads(py_string);


### PR DESCRIPTION
The `auto_ptr` would use `delete p` to free an array allocated with `operator new[]`, which could result in heap corruption. Replaced it with `scoped_array`.

As an additional bonus, this gets rid of the warnings about using a deprecated component in C++11 mode.