### PR TITLE
Replace boost::serialization::detail::get_data function.

### DIFF
--- a/include/boost/mpi/detail/mpi_datatype_primitive.hpp
+++ b/include/boost/mpi/detail/mpi_datatype_primitive.hpp
@@ -25,7 +25,6 @@ namespace std{
 #include <boost/assert.hpp>
 #include <boost/mpl/placeholders.hpp>
 #include <boost/serialization/array.hpp>
-#include <boost/serialization/detail/get_data.hpp>
 #include <stdexcept>
 #include <iostream>
 #include <vector>
@@ -80,18 +79,18 @@ public:
        BOOST_MPI_CHECK_RESULT(MPI_Type_create_struct,
                     (
                       addresses.size(),
-                      boost::serialization::detail::get_data(lengths),
-                      boost::serialization::detail::get_data(addresses),
-                      boost::serialization::detail::get_data(types),
+                      get_data(lengths),
+                      get_data(addresses),
+                      get_data(types),
                       &datatype_
                     ));
 #else
         BOOST_MPI_CHECK_RESULT(MPI_Type_struct,
                                (
                                 addresses.size(),
-                                boost::serialization::detail::get_data(lengths),
-                                boost::serialization::detail::get_data(addresses),
-                                boost::serialization::detail::get_data(types),
+                                get_data(lengths),
+                                get_data(addresses),
+                                get_data(types),
                                 &datatype_
                                 ));
 #endif
@@ -127,6 +126,12 @@ private:
       addresses.push_back(a-origin);
       types.push_back(t);
       lengths.push_back(l);
+    }
+
+    template <class T>
+    static T* get_data(std::vector<T>& v)
+    {
+      return v.empty() ? 0 : &(v[0]);
     }
 
     std::vector<MPI_Aint> addresses;

--- a/include/boost/mpi/detail/packed_iprimitive.hpp
+++ b/include/boost/mpi/detail/packed_iprimitive.hpp
@@ -16,7 +16,6 @@
 #include <boost/mpi/exception.hpp>
 #include <boost/assert.hpp>
 #include <boost/serialization/array.hpp>
-#include <boost/serialization/detail/get_data.hpp>
 #include <vector>
 #include <boost/mpi/allocator.hpp>
 
@@ -104,7 +103,12 @@ private:
     void load_impl(void * p, MPI_Datatype t, int l)
     {
       BOOST_MPI_CHECK_RESULT(MPI_Unpack,
-        (const_cast<char*>(boost::serialization::detail::get_data(buffer_)), buffer_.size(), &position, p, l, t, comm));
+        (get_data(buffer_), buffer_.size(), &position, p, l, t, comm));
+    }
+
+    static buffer_type::value_type* get_data(buffer_type& b)
+    {
+      return b.empty() ? 0 : &(b[0]);
     }
 
     buffer_type & buffer_;

--- a/include/boost/mpi/detail/packed_oprimitive.hpp
+++ b/include/boost/mpi/detail/packed_oprimitive.hpp
@@ -15,7 +15,6 @@
 
 #include <boost/mpi/datatype.hpp>
 #include <boost/mpi/exception.hpp>
-#include <boost/serialization/detail/get_data.hpp>
 #include <boost/serialization/array.hpp>
 #include <boost/assert.hpp>
 #include <vector>
@@ -103,11 +102,16 @@ private:
 
       // pack the data into the buffer
       BOOST_MPI_CHECK_RESULT(MPI_Pack,
-      (const_cast<void*>(p), l, t, boost::serialization::detail::get_data(buffer_), buffer_.size(), &position, comm));
+      (const_cast<void*>(p), l, t, get_data(buffer_), buffer_.size(), &position, comm));
       // reduce the buffer size if needed
       BOOST_ASSERT(std::size_t(position) <= buffer_.size());
       if (std::size_t(position) < buffer_.size())
           buffer_.resize(position);
+    }
+
+    static buffer_type::value_type* get_data(buffer_type& b)
+    {
+      return b.empty() ? 0 : &(b[0]);
     }
 
   buffer_type& buffer_;


### PR DESCRIPTION
Several Boost.MPI headers include `<boost/serialization/detail/get_data.hpp>` which was removed by https://github.com/boostorg/serialization/commit/d558b6da917ecae1036adf9b22a0741c78f627ff

This causes multiple build failures with the current snapshot at http://downloads.sourceforge.net/boost/boost_1_63_0.tar.bz2

````
    "g++"  -g -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -fn
o-strict-aliasing -Wno-unused-local-typedefs -pthread -fPIC  -DBOOST_ALL_NO_LIB=1 -DBOOST_GRAPH_DYN_LINK=1 -DBOOST_GRAPH_NO_LIB=1 -DNDEBUG  -I"." -I"/usr/include/openmpi-x86_64" -I"libs/graph_parallel/src" -c -o "openmpi-x86_64/boost/bin
.v2/libs/graph_parallel/build/gcc-6.3.1/release/debug-symbols-on/pch-off/threading-multi/mpi_process_group.o" "libs/graph_parallel/src/mpi_process_group.cpp"

In file included from ./boost/mpi/detail/mpi_datatype_oarchive.hpp:18:0,
                from ./boost/mpi/detail/mpi_datatype_cache.hpp:13,
                from ./boost/mpi/datatype.hpp:27,
                from ./boost/mpi/communicator.hpp:22,
                from ./boost/mpi/collectives.hpp:21,
                from ./boost/mpi.hpp:23,
                from ./boost/graph/distributed/mpi_process_group.hpp:30,
                from libs/graph_parallel/src/mpi_process_group.cpp:14:
./boost/mpi/detail/mpi_datatype_primitive.hpp:28:51: fatal error: boost/serialization/detail/get_data.hpp: No such file or directory
#include <boost/serialization/detail/get_data.hpp>
                                                  ^
compilation terminated.
````
There are other failures due to `packed_oprimitive` and `packed_iprimitive` also using the missing header.

Since only one function from the header is needed the simplest thing is to just define that function locally in the classes that need it.

