### PR TITLE
Adapt to serialization/develop updates.

### DIFF
--- a/include/boost/mpi/communicator.hpp
+++ b/include/boost/mpi/communicator.hpp
@@ -34,7 +34,6 @@
 #include <boost/mpi/skeleton_and_content_fwd.hpp>
 
 // For (de-)serializing arrays
-#include <boost/serialization/array.hpp>
 
 #include <boost/mpi/detail/point_to_point.hpp>
 #include <boost/mpi/status.hpp>

--- a/include/boost/mpi/detail/binary_buffer_iprimitive.hpp
+++ b/include/boost/mpi/detail/binary_buffer_iprimitive.hpp
@@ -16,7 +16,6 @@
 #include <boost/mpi/exception.hpp>
 #include <boost/assert.hpp>
 #include <boost/mpl/assert.hpp>
-#include <boost/serialization/array.hpp>
 #include <boost/serialization/is_bitwise_serializable.hpp>
 #include <vector>
 #include <boost/mpi/allocator.hpp>

--- a/include/boost/mpi/detail/binary_buffer_oprimitive.hpp
+++ b/include/boost/mpi/detail/binary_buffer_oprimitive.hpp
@@ -14,7 +14,6 @@
 #include <cstddef> // size_t
 #include <boost/config.hpp>
 
-#include <boost/serialization/array.hpp>
 #include <boost/serialization/is_bitwise_serializable.hpp>
 #include <boost/assert.hpp>
 #include <boost/mpl/assert.hpp>

--- a/include/boost/mpi/detail/forward_iprimitive.hpp
+++ b/include/boost/mpi/detail/forward_iprimitive.hpp
@@ -6,8 +6,6 @@
 
 //  Authors: Matthias Troyer
 
-#include <boost/serialization/array.hpp>
-
 #ifndef BOOST_MPI_DETAIL_FORWARD_IPRIMITIVE_HPP
 #define BOOST_MPI_DETAIL_FORWARD_IPRIMITIVE_HPP
 

--- a/include/boost/mpi/detail/forward_oprimitive.hpp
+++ b/include/boost/mpi/detail/forward_oprimitive.hpp
@@ -10,7 +10,6 @@
 #define BOOST_MPI_DETAIL_FORWARD_OPRIMITIVE_HPP
 
 #include <boost/config.hpp>
-#include <boost/serialization/array.hpp>
 
 namespace boost { namespace mpi { namespace detail {
 

--- a/include/boost/mpi/detail/ignore_iprimitive.hpp
+++ b/include/boost/mpi/detail/ignore_iprimitive.hpp
@@ -11,7 +11,6 @@
 
 #include <boost/config.hpp>
 #include <boost/mpi/datatype.hpp>
-#include <boost/serialization/array.hpp>
 
 
 namespace boost { namespace mpi { namespace detail {

--- a/include/boost/mpi/detail/ignore_oprimitive.hpp
+++ b/include/boost/mpi/detail/ignore_oprimitive.hpp
@@ -11,7 +11,6 @@
 
 #include <boost/config.hpp>
 #include <boost/mpi/datatype.hpp>
-#include <boost/serialization/array.hpp>
 
 namespace boost { namespace mpi { namespace detail {
 

--- a/include/boost/mpi/detail/ignore_skeleton_oarchive.hpp
+++ b/include/boost/mpi/detail/ignore_skeleton_oarchive.hpp
@@ -14,7 +14,6 @@
 #include <boost/archive/basic_archive.hpp>
 #include <boost/archive/detail/oserializer.hpp>
 #include <boost/serialization/collection_size_type.hpp>
-#include <boost/serialization/array.hpp>
 #include <boost/serialization/item_version_type.hpp>
 
 namespace boost { namespace mpi { namespace detail {

--- a/include/boost/mpi/detail/mpi_datatype_primitive.hpp
+++ b/include/boost/mpi/detail/mpi_datatype_primitive.hpp
@@ -24,8 +24,6 @@ namespace std{
 #include <boost/throw_exception.hpp>
 #include <boost/assert.hpp>
 #include <boost/mpl/placeholders.hpp>
-#include <boost/serialization/array.hpp>
-#include <boost/serialization/detail/get_data.hpp>
 #include <stdexcept>
 #include <iostream>
 #include <vector>
@@ -80,18 +78,18 @@ public:
        BOOST_MPI_CHECK_RESULT(MPI_Type_create_struct,
                     (
                       addresses.size(),
-                      boost::serialization::detail::get_data(lengths),
-                      boost::serialization::detail::get_data(addresses),
-                      boost::serialization::detail::get_data(types),
+                      lengths.data(),
+                      addresses.data(),
+                      types.data(),
                       &datatype_
                     ));
 #else
         BOOST_MPI_CHECK_RESULT(MPI_Type_struct,
                                (
                                 addresses.size(),
-                                boost::serialization::detail::get_data(lengths),
-                                boost::serialization::detail::get_data(addresses),
-                                boost::serialization::detail::get_data(types),
+				lengths.data(),
+                                addresses.data(),
+                                types.data(),
                                 &datatype_
                                 ));
 #endif

--- a/include/boost/mpi/detail/packed_iprimitive.hpp
+++ b/include/boost/mpi/detail/packed_iprimitive.hpp
@@ -15,8 +15,6 @@
 #include <boost/mpi/datatype.hpp>
 #include <boost/mpi/exception.hpp>
 #include <boost/assert.hpp>
-#include <boost/serialization/array.hpp>
-#include <boost/serialization/detail/get_data.hpp>
 #include <vector>
 #include <boost/mpi/allocator.hpp>
 
@@ -104,7 +102,8 @@ private:
     void load_impl(void * p, MPI_Datatype t, int l)
     {
       BOOST_MPI_CHECK_RESULT(MPI_Unpack,
-        (const_cast<char*>(boost::serialization::detail::get_data(buffer_)), buffer_.size(), &position, p, l, t, comm));
+			     (const_cast<char*>(buffer_.data()),
+			      buffer_.size(), &position, p, l, t, comm));
     }
 
     buffer_type & buffer_;

--- a/include/boost/mpi/detail/packed_oprimitive.hpp
+++ b/include/boost/mpi/detail/packed_oprimitive.hpp
@@ -15,8 +15,6 @@
 
 #include <boost/mpi/datatype.hpp>
 #include <boost/mpi/exception.hpp>
-#include <boost/serialization/detail/get_data.hpp>
-#include <boost/serialization/array.hpp>
 #include <boost/assert.hpp>
 #include <vector>
 #include <boost/mpi/allocator.hpp>
@@ -103,7 +101,8 @@ private:
 
       // pack the data into the buffer
       BOOST_MPI_CHECK_RESULT(MPI_Pack,
-      (const_cast<void*>(p), l, t, boost::serialization::detail::get_data(buffer_), buffer_.size(), &position, comm));
+			     (const_cast<void*>(p), l, t,
+			      buffer_.data(), buffer_.size(), &position, comm));
       // reduce the buffer size if needed
       BOOST_ASSERT(std::size_t(position) <= buffer_.size());
       if (std::size_t(position) < buffer_.size())

--- a/include/boost/mpi/python/serialize.hpp
+++ b/include/boost/mpi/python/serialize.hpp
@@ -35,7 +35,6 @@
 #include <boost/mpl/if.hpp>
 
 #include <boost/serialization/split_free.hpp>
-#include <boost/serialization/array.hpp>
 
 #include <boost/assert.hpp>
 


### PR DESCRIPTION
Remove all occurences of serialization/array.hpp, which apparently were not used (all test passes without them) and is only availlable in c++11 mode ( serialization/array.hp includes <array>, g++5.x will fail, and we don't use std::array anyway).

also, serialization/detail/get_data has disapeared, so we now use the std::<container>::data() method directly.