### PR TITLE
Fix mpi-python component compilation.

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -21,8 +21,8 @@ project boost/mpi
   : source-location ../src
   ;
 
-lib boost_mpi 
-  : 
+lib boost_mpi
+  :
     broadcast.cpp
     cartesian_communicator.cpp
     communicator.cpp
@@ -55,55 +55,86 @@ lib boost_mpi
     <library>../../serialization/build//boost_serialization
     <library>/mpi//mpi [ mpi.extra-requirements ]
   ;
-  
-libraries += boost_mpi ;  
+
+libraries += boost_mpi ;
 
   if [ python.configured ]
   {
-    lib boost_mpi_python
-      : # Sources
-        python/serialize.cpp
-      : # Requirements
-        <library>boost_mpi
-        <library>/mpi//mpi [ mpi.extra-requirements ]
-      	<library>/boost/python//boost_python
-        <link>shared:<define>BOOST_MPI_DYN_LINK=1
-        <link>shared:<define>BOOST_MPI_PYTHON_DYN_LINK=1
-        <link>shared:<define>BOOST_PYTHON_DYN_LINK=1        
-        <define>BOOST_MPI_PYTHON_SOURCE=1
-	-<tag>@$(BOOST_JAMROOT_MODULE)%$(BOOST_JAMROOT_MODULE).tag
-	<tag>@$(BOOST_JAMROOT_MODULE)%$(BOOST_JAMROOT_MODULE).python-tag
-      : # Default build
-        <link>shared
-      : # Usage requirements
-        <library>/mpi//mpi [ mpi.extra-requirements ]
-      ;
-    libraries += boost_mpi_python ;   
+    py2-version = [ py-version 2 ] ;
+    py3-version = [ py-version 3 ] ;
 
-    python-extension mpi 
-      : # Sources
-        python/collectives.cpp
-        python/py_communicator.cpp
-        python/datatypes.cpp
-        python/documentation.cpp
-        python/py_environment.cpp
-        python/py_nonblocking.cpp
-        python/py_exception.cpp
-        python/module.cpp
-        python/py_request.cpp
-        python/skeleton_and_content.cpp
-        python/status.cpp
-        python/py_timer.cpp
-      : # Requirements
-      	<library>/boost/python//boost_python      
-        <library>boost_mpi_python
-        <library>boost_mpi
-        <library>/mpi//mpi [ mpi.extra-requirements ]
-        <link>shared:<define>BOOST_MPI_DYN_LINK=1    
-        <link>shared:<define>BOOST_MPI_PYTHON_DYN_LINK=1        
-        <link>shared:<define>BOOST_PYTHON_DYN_LINK=1    
-        <link>shared <runtime-link>shared
-      ;
+    # These library names are synchronized with those defined by Boost.Python, see libs/python/build/Jamfile.
+    lib_boost_python(2) = boost_python ;
+    lib_boost_python(3) = boost_python3 ;
+
+    lib_boost_python($(py2-version)) = $(lib_boost_python(2)) ;
+    lib_boost_python($(py3-version)) = $(lib_boost_python(3)) ;
+
+    lib_boost_mpi_python(2) = boost_mpi_python ;
+    lib_boost_mpi_python(3) = boost_mpi_python3 ;
+
+    lib_boost_mpi_python($(py2-version)) = $(lib_boost_mpi_python(2)) ;
+    lib_boost_mpi_python($(py3-version)) = $(lib_boost_mpi_python(3)) ;
+
+    for local N in 2 3
+    {
+        if $(py$(N)-version)
+        {
+            lib $(lib_boost_mpi_python($(py$(N)-version)))
+              : # Sources
+                python/serialize.cpp
+              : # Requirements
+                <library>boost_mpi
+                <library>/mpi//mpi [ mpi.extra-requirements ]
+                <library>/boost/python//$(lib_boost_python($(py$(N)-version)))
+                <link>shared:<define>BOOST_MPI_DYN_LINK=1
+                <link>shared:<define>BOOST_MPI_PYTHON_DYN_LINK=1
+                <link>shared:<define>BOOST_PYTHON_DYN_LINK=1
+                <define>BOOST_MPI_PYTHON_SOURCE=1
+                -<tag>@$(BOOST_JAMROOT_MODULE)%$(BOOST_JAMROOT_MODULE).tag
+                <tag>@$(BOOST_JAMROOT_MODULE)%$(BOOST_JAMROOT_MODULE).python-tag
+                <python-debugging>on:<define>BOOST_DEBUG_PYTHON
+                <python>$(py$(N)-version)
+              : # Default build
+                <link>shared
+              : # Usage requirements
+                <library>/mpi//mpi [ mpi.extra-requirements ]
+              ;
+
+            python-extension mpi
+              : # Sources
+                python/collectives.cpp
+                python/py_communicator.cpp
+                python/datatypes.cpp
+                python/documentation.cpp
+                python/py_environment.cpp
+                python/py_nonblocking.cpp
+                python/py_exception.cpp
+                python/module.cpp
+                python/py_request.cpp
+                python/skeleton_and_content.cpp
+                python/status.cpp
+                python/py_timer.cpp
+              : # Requirements
+                <library>/boost/python//$(lib_boost_python($(py$(N)-version)))
+                <library>$(lib_boost_mpi_python($(py$(N)-version)))
+                <library>boost_mpi
+                <library>/mpi//mpi [ mpi.extra-requirements ]
+                <link>shared:<define>BOOST_MPI_DYN_LINK=1
+                <link>shared:<define>BOOST_MPI_PYTHON_DYN_LINK=1
+                <link>shared:<define>BOOST_PYTHON_DYN_LINK=1
+                <link>shared <runtime-link>shared
+                <python-debugging>on:<define>BOOST_DEBUG_PYTHON
+                <python>$(py$(N)-version)
+              ;
+
+            libraries += $(lib_boost_mpi_python($(py$(N)-version))) ;
+        }
+        else
+        {
+            alias $(lib_boost_mpi_python($(N))) ;
+        }
+    }
   }
 }
 else if ! ( --without-mpi in  [ modules.peek : ARGV ] )


### PR DESCRIPTION
This fixes Boost.MPI 1.64 compilation:

```
gcc.compile.c++ bin.v2/libs/mpi/build/gcc-6.3.0/release/debug-symbols-on/threading-multi/python/serialize.o
In file included from ./boost/python/detail/prefix.hpp:13:0,
                 from ./boost/python/ssize_t.hpp:9,
                 from ./boost/python/object.hpp:8,
                 from ./boost/mpi/python/serialize.hpp:25,
                 from libs/mpi/src/python/serialize.cpp:13:
./boost/python/detail/wrap_python.hpp:50:23: fatal error: pyconfig.h: No such file or directory
 # include <pyconfig.h>
                       ^
compilation terminated.
    
    "g++"  -ftemplate-depth-128 -O3 -finline-functions -Wno-inline -Wall -g -pthread -fPIC -m64 -std=gnu++0x -DBOOST_ALL_NO_LIB=1 -DBOOST_MPI_DYN_LINK=1 -DBOOST_MPI_PYTHON_DYN_LINK=1 -DBOOST_MPI_PYTHON_SOURCE=1 -DBOOST_PYTHON_DYN_LINK=1 -DNDEBUG  -I"." -I"/usr/lib/x86_64-linux-gnu/ope
    
...failed gcc.compile.c++ bin.v2/libs/mpi/build/gcc-6.3.0/release/debug-symbols-on/threading-multi/python/serialize.o...
```

Make mpi-python compilation and naming consistent with Boost.Python:

- Add <python> property requirement to the components dependent on Python.
  This ensures that Boost.Build passes include and library paths for the
  selected Python version while building these components. This fixes the
  build error of pyconfig.h not found.

- Add <python-debugging> property handling, to follow Boost.Python practice.
  This should ensure that correct Python headers and library are used
  by Boost.Python depending on this property.

- Add suffix 3 to the library name when compiled against Python 3.x. This
  follows Boost.Python practice. The MPI plugin for Python is still named
  mpi (without suffix) as it may be visible to python programs. Users are
  expected to build into separate directories when plugins for different
  Python versions are required.
