### PR TITLE
Do not include serialization/detail/get_data.hpp as it disapear in 1.64.

### DIFF
--- a/include/boost/mpi/detail/antiques.hpp
+++ b/include/boost/mpi/detail/antiques.hpp
@@ -1,0 +1,29 @@
+//          Copyright Alain Miniussi 2014.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+// Authors: Alain Miniussi
+
+#ifndef BOOST_MPI_ANTIQUES_HPP
+#define BOOST_MPI_ANTIQUES_HPP
+
+#include <vector>
+
+// Support for some obsolette compilers
+
+namespace boost { namespace mpi {
+    namespace detail {
+      // Some old gnu compiler have no support for vector<>::data
+      // Use this in the mean time, the cumbersome syntax should 
+      // serve as an incentive to get rid of this when those compilers 
+      // are dropped.
+      template <typename T, typename A>
+      T* c_data(std::vector<T,A>& v) { return &(v[0]); }
+
+      template <typename T, typename A>
+      T const* c_data(std::vector<T,A> const& v) { return &(v[0]); }
+  
+} } }
+
+#endif

--- a/include/boost/mpi/detail/mpi_datatype_primitive.hpp
+++ b/include/boost/mpi/detail/mpi_datatype_primitive.hpp
@@ -25,10 +25,10 @@ namespace std{
 #include <boost/assert.hpp>
 #include <boost/mpl/placeholders.hpp>
 #include <boost/serialization/array.hpp>
-#include <boost/serialization/detail/get_data.hpp>
 #include <stdexcept>
 #include <iostream>
 #include <vector>
+#include <boost/mpi/detail/antiques.hpp>
 
 namespace boost { namespace mpi { namespace detail {
 
@@ -80,18 +80,18 @@ public:
        BOOST_MPI_CHECK_RESULT(MPI_Type_create_struct,
                     (
                       addresses.size(),
-                      boost::serialization::detail::get_data(lengths),
-                      boost::serialization::detail::get_data(addresses),
-                      boost::serialization::detail::get_data(types),
+                      c_data(lengths),
+                      c_data(addresses),
+                      c_data(types),
                       &datatype_
                     ));
 #else
         BOOST_MPI_CHECK_RESULT(MPI_Type_struct,
                                (
                                 addresses.size(),
-                                boost::serialization::detail::get_data(lengths),
-                                boost::serialization::detail::get_data(addresses),
-                                boost::serialization::detail::get_data(types),
+                                c_data(lengths),
+                                c_data(addresses),
+                                c_data(types),
                                 &datatype_
                                 ));
 #endif

--- a/include/boost/mpi/detail/packed_iprimitive.hpp
+++ b/include/boost/mpi/detail/packed_iprimitive.hpp
@@ -16,8 +16,8 @@
 #include <boost/mpi/exception.hpp>
 #include <boost/assert.hpp>
 #include <boost/serialization/array.hpp>
-#include <boost/serialization/detail/get_data.hpp>
 #include <vector>
+#include <boost/mpi/detail/antiques.hpp>
 #include <boost/mpi/allocator.hpp>
 
 namespace boost { namespace mpi {
@@ -104,7 +104,7 @@ private:
     void load_impl(void * p, MPI_Datatype t, int l)
     {
       BOOST_MPI_CHECK_RESULT(MPI_Unpack,
-        (const_cast<char*>(boost::serialization::detail::get_data(buffer_)), buffer_.size(), &position, p, l, t, comm));
+                             (const_cast<char*>(detail::c_data(buffer_)), buffer_.size(), &position, p, l, t, comm));
     }
 
     buffer_type & buffer_;

--- a/include/boost/mpi/detail/packed_oprimitive.hpp
+++ b/include/boost/mpi/detail/packed_oprimitive.hpp
@@ -15,7 +15,7 @@
 
 #include <boost/mpi/datatype.hpp>
 #include <boost/mpi/exception.hpp>
-#include <boost/serialization/detail/get_data.hpp>
+#include <boost/mpi/detail/antiques.hpp>
 #include <boost/serialization/array.hpp>
 #include <boost/assert.hpp>
 #include <vector>
@@ -98,7 +98,10 @@ private:
 
       // pack the data into the buffer
       BOOST_MPI_CHECK_RESULT(MPI_Pack,
-      (const_cast<void*>(p), l, t, boost::serialization::detail::get_data(buffer_), buffer_.size(), &position, comm));
+                             (const_cast<void*>(p),l,t, 
+                              detail::c_data(buffer_),
+                              buffer_.size(), 
+                              &position,comm));
       // reduce the buffer size if needed
       BOOST_ASSERT(std::size_t(position) <= buffer_.size());
       if (std::size_t(position) < buffer_.size())


### PR DESCRIPTION
All in the title.
1.64 was not building on most platform and was working for the wrong reason on others (presence of /usr/include/boost/serialization/detail/get_data.hpp")
