### PR TITLE
Add const conversion to accomodate open MPI 1.6

### DIFF
--- a/include/boost/mpi/detail/antiques.hpp
+++ b/include/boost/mpi/detail/antiques.hpp
@@ -23,7 +23,18 @@ namespace detail {
 
   template <typename T, typename A>
   T const* c_data(std::vector<T,A> const& v) { return &(v[0]); }
-  
+
+  // Some old MPI implementation (OpenMPI 1.6 for example) have non 
+  // conforming API w.r.t. constness.
+  // We choose to fix this trhough this converter in order to 
+  // explain/remember why we're doing this and remove it easilly 
+  // when support for those MPI is dropped.
+  // The fix is as specific (un templatized, for one) as possible 
+  // in order to encourage it usage for the probleme at hand.
+  // Problematic API include MPI_Send
+  inline
+  void *unconst(void const* addr) { return const_cast<void*>(addr); }
+
 } } }
 
 #endif

--- a/src/point_to_point.cpp
+++ b/src/point_to_point.cpp
@@ -20,6 +20,7 @@
 #include <boost/mpi/detail/point_to_point.hpp>
 #include <boost/mpi/datatype.hpp>
 #include <boost/mpi/exception.hpp>
+#include <boost/mpi/detail/antiques.hpp>
 #include <cassert>
 
 namespace boost { namespace mpi { namespace detail {
@@ -30,11 +31,11 @@ packed_archive_send(MPI_Comm comm, int dest, int tag,
 {
   std::size_t const& size = ar.size();
   BOOST_MPI_CHECK_RESULT(MPI_Send,
-                         (&size, 1, 
+                         (detail::unconst(&size), 1, 
                           get_mpi_datatype(size), 
                           dest, tag, comm));
   BOOST_MPI_CHECK_RESULT(MPI_Send,
-                         (const_cast<void*>(ar.address()), size,
+                         (detail::unconst(ar.address()), size,
                           MPI_PACKED,
                           dest, tag, comm));
 }
@@ -47,11 +48,11 @@ packed_archive_isend(MPI_Comm comm, int dest, int tag,
   assert(num_out_requests >= 2);
   std::size_t const& size = ar.size();
   BOOST_MPI_CHECK_RESULT(MPI_Isend,
-                         (&size, 1, 
+                         (detail::unconst(&size), 1, 
                           get_mpi_datatype(size),
                           dest, tag, comm, out_requests));
   BOOST_MPI_CHECK_RESULT(MPI_Isend,
-                         (const_cast<void*>(ar.address()), size,
+                         (detail::unconst(ar.address()), size,
                           MPI_PACKED,
                           dest, tag, comm, out_requests + 1));
 
@@ -67,11 +68,11 @@ packed_archive_isend(MPI_Comm comm, int dest, int tag,
 
   std::size_t const& size = ar.size();
   BOOST_MPI_CHECK_RESULT(MPI_Isend,
-                         (&size, 1, 
+                         (detail::unconst(&size), 1, 
                           get_mpi_datatype(size), 
                           dest, tag, comm, out_requests));
   BOOST_MPI_CHECK_RESULT(MPI_Isend,
-                         (const_cast<void*>(ar.address()), size,
+                         (detail::unconst(ar.address()), size,
                           MPI_PACKED,
                           dest, tag, comm, out_requests + 1));
 


### PR DESCRIPTION
Some (old) MPI implementation have a non conforming signature w.r.t.
This is the case for **MPI_Send**, those signature should be, according to the [standard](http://mpi-forum.org/docs/mpi-3.1/mpi31-report.pdf#56):
{{{
int MPI_Send(const void* buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm)
}}}
