### PR TITLE
Fix dangling pointer to custom operation in collectives

### DIFF
--- a/include/boost/mpi/collectives/all_reduce.hpp
+++ b/include/boost/mpi/collectives/all_reduce.hpp
@@ -51,7 +51,8 @@ namespace detail {
                   T* out_values, Op op, mpl::false_ /*is_mpi_op*/,
                   mpl::true_ /*is_mpi_datatype*/)
   {
-    user_op<Op, T> mpi_op(op);
+    static Op lop = op;
+    user_op<Op, T> mpi_op(lop);
     BOOST_MPI_CHECK_RESULT(MPI_Allreduce,
                            (const_cast<T*>(in_values), out_values, n,
                             boost::mpi::get_mpi_datatype<T>(*in_values),

--- a/include/boost/mpi/collectives/reduce.hpp
+++ b/include/boost/mpi/collectives/reduce.hpp
@@ -81,7 +81,8 @@ namespace detail {
               T* out_values, Op op, int root, mpl::false_ /*is_mpi_op*/,
               mpl::true_/*is_mpi_datatype*/)
   {
-    user_op<Op, T> mpi_op(op);
+    static Op lop = op;
+    user_op<Op, T> mpi_op(lop);
     BOOST_MPI_CHECK_RESULT(MPI_Reduce,
                            (const_cast<T*>(in_values), out_values, n,
                             boost::mpi::get_mpi_datatype<T>(*in_values),
@@ -96,7 +97,8 @@ namespace detail {
   reduce_impl(const communicator& comm, const T* in_values, int n, Op op,
               int root, mpl::false_/*is_mpi_op*/, mpl::true_/*is_mpi_datatype*/)
   {
-    user_op<Op, T> mpi_op(op);
+    static Op lop = op;
+    user_op<Op, T> mpi_op(lop);
     BOOST_MPI_CHECK_RESULT(MPI_Reduce,
                            (const_cast<T*>(in_values), 0, n,
                             boost::mpi::get_mpi_datatype<T>(*in_values),

--- a/include/boost/mpi/collectives/scan.hpp
+++ b/include/boost/mpi/collectives/scan.hpp
@@ -67,7 +67,8 @@ namespace detail {
   scan_impl(const communicator& comm, const T* in_values, int n, T* out_values,
             Op op, mpl::false_ /*is_mpi_op*/, mpl::true_ /*is_mpi_datatype*/)
   {
-    user_op<Op, T> mpi_op(op);
+    static Op lop = op;
+    user_op<Op, T> mpi_op(lop);
     BOOST_MPI_CHECK_RESULT(MPI_Scan,
                            (const_cast<T*>(in_values), out_values, n,
                             boost::mpi::get_mpi_datatype<T>(*in_values),


### PR DESCRIPTION
Found with Clang-Tidy in Boost 1.58.

```
/usr/include/boost/mpi/collectives/all_reduce.hpp:59:3: error: Address of stack memory associated with local variable 'op' is still referred to by the global variable 'op_ptr' upon returning to the caller.  This will be a dangling reference [clang-analyzer-core.StackAddressEscape,-warnings-as-errors]
  }
  ^
main.cpp:54:3: note: Calling 'all_reduce'
  boost::mpi::all_reduce(comm, value == root_value, is_same,
  ^
/usr/include/boost/mpi/collectives/all_reduce.hpp:115:3: note: Calling 'all_reduce_impl'
  detail::all_reduce_impl(comm, &in_value, 1, &out_value, op,
  ^
/usr/include/boost/mpi/collectives/all_reduce.hpp:59:3: note: Address of stack memory associated with local variable 'op' is still referred to by the global variable 'op_ptr' upon returning to the caller.  This will be a dangling reference
  }
  ^
```

`user_op` takes a reference to `op` and `all_reduce_impl`/`reduce_impl`/`scan_impl` take it by value, so this seems to be the only place where this can be fixed.