### PR TITLE
Fix error in boost::mpi::wait_any (possible deadlock)

### DIFF
--- a/include/boost/mpi/nonblocking.hpp
+++ b/include/boost/mpi/nonblocking.hpp
@@ -59,9 +59,8 @@ wait_any(ForwardIterator first, ForwardIterator last)
   ForwardIterator current = first;
   while (true) {
     // Check if we have found a completed request. If so, return it.
-    if (current->m_requests[0] != MPI_REQUEST_NULL &&
-        (current->m_requests[1] != MPI_REQUEST_NULL ||
-         current->m_handler)) {
+    if (current->m_requests[0] != MPI_REQUEST_NULL ||
+        (current->m_requests[1] != MPI_REQUEST_NULL)
       if (optional<status> result = current->test())
         return std::make_pair(*result, current);
     }


### PR DESCRIPTION
When using nonblocking communication with serialized data, boost::mpi::wait_any can deadlock if one calls wait_any until all data is received. The problem is that `current->m_requests[0]` can be `MPI_REQUEST_NULL` but the data has not actually been received, i.e. `current->m_requests[1] != MPI_REQUEST_NULL`.

This is because `MPI_Test` as called from `handle_serialized_irecv` sets the request it is given to `MPI_REQUEST_NULL` if the communication has completed. If, however, only the count has already been received by MPI but not the data itself the `MPI_Test` call on `m_requests[1]` returns `flag = false` and leaves an open `boost::request` where `m_requests[0] == MPI_REQUEST_NULL` and `m_requests[1] != MPI_REQUEST_NULL`.

I propose to fix this by querying if any of the two MPI_Request members is not `MPI_REQUEST_NULL`. However, since I have only looked at this particular problem, I might be missing some other features/details that actually need a more elaborate conditional.
