### PR TITLE
Add MPI error code to string convertion

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -29,6 +29,7 @@ lib boost_mpi
     computation_tree.cpp
     content_oarchive.cpp
     environment.cpp
+    error_string.cpp
     exception.cpp
     graph_communicator.cpp
     group.cpp

--- a/include/boost/mpi/error_string.hpp
+++ b/include/boost/mpi/error_string.hpp
@@ -1,0 +1,26 @@
+// Copyright (C) 2018 Alain Miniussi <alain.miniussi -at- oca.eu>.
+
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/** @file error_string.hpp
+ *
+ *  Error code to string convertion.
+ */
+#ifndef BOOST_MPI_ERROR_STRING_HPP
+#define BOOST_MPI_ERROR_STRING_HPP
+
+#include <boost/mpi/config.hpp>
+#include <string>
+
+namespace boost { namespace mpi {
+
+/**
+ * @brief Convert a MPI error code to an error string.
+ */
+std::string error_string(int err_code);
+
+} } // end namespace boost::mpi
+
+#endif // BOOST_MPI_ERROR_STRING_HPP

--- a/include/boost/mpi/exception.hpp
+++ b/include/boost/mpi/exception.hpp
@@ -104,3 +104,4 @@ class BOOST_MPI_DECL exception : public std::exception
 } } // end namespace boost::mpi
 
 #endif // BOOST_MPI_EXCEPTION_HPP
+

--- a/src/error_string.cpp
+++ b/src/error_string.cpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2018 Alain Miniussi <alain.miniussi -at- oca.eu>.
+
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <sstream>
+#include <boost/mpi/error_string.hpp>
+
+namespace boost { namespace mpi {
+
+std::string
+error_string(int err)
+{
+  char buffer[MPI_MAX_ERROR_STRING];
+  int len;
+  int status = MPI_Error_string(err, buffer, &len);
+  if (status == MPI_SUCCESS) {
+    return std::string(buffer);
+  } else {
+    std::ostringstream out;
+    if (status == MPI_ERR_ARG) {
+      out << "<invalid MPI error code " << err << ">";
+    } else {
+      out << "<got error " << status 
+          << " while probing MPI error " << err << ">";
+    }
+    return out.str();
+  }
+}
+    
+} }

--- a/src/error_string.cpp
+++ b/src/error_string.cpp
@@ -9,8 +9,7 @@
 
 namespace boost { namespace mpi {
 
-std::string
-error_string(int err)
+std::string error_string(int err)
 {
   char buffer[MPI_MAX_ERROR_STRING];
   int len;

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -7,21 +7,16 @@
 // License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 #include <boost/mpi/exception.hpp>
+#include <boost/mpi/error_string.hpp>
 
 namespace boost { namespace mpi {
 
 exception::exception(const char* routine, int result_code)
   : routine_(routine), result_code_(result_code)
 {
-  // Query the MPI implementation for its reason for failure
-  char buffer[MPI_MAX_ERROR_STRING];
-  int len;
-  MPI_Error_string(result_code, buffer, &len);
-
-  // Construct the complete error message
   message.append(routine_);
   message.append(": ");
-  message.append(buffer, len);
+  message.append(error_string(result_code));
 }
 
 exception::~exception() throw() { }


### PR DESCRIPTION
We are missing a clean conversion from MPI error code to strings.
This is a C++ version of MPI_Error_string
