### PR TITLE
Bug with move ctor signature

### DIFF
--- a/include/boost/mpi/cartesian_communicator.hpp
+++ b/include/boost/mpi/cartesian_communicator.hpp
@@ -116,12 +116,13 @@ class BOOST_MPI_DECL cartesian_topology
   cartesian_topology& operator=(cartesian_topology const&) = default;
   // There is apparently no macro for checking the support of move constructor.
   // Assume that defaulted function is close enough.
+#if !defined(BOOST_NO_CXX11_DEFAULTED_MOVES)
   cartesian_topology(cartesian_topology&& other) : super(other) {}
   cartesian_topology& operator=(cartesian_topology&& other) { 
     stl().swap(other.stl());
     return *this;
   }
-
+#endif
   ~cartesian_topology() = default;
 #endif
   /**

--- a/include/boost/mpi/cartesian_communicator.hpp
+++ b/include/boost/mpi/cartesian_communicator.hpp
@@ -116,9 +116,9 @@ class BOOST_MPI_DECL cartesian_topology
   cartesian_topology& operator=(cartesian_topology const&) = default;
   // There is apparently no macro for checking the support of move constructor.
   // Assume that defaulted function is close enough.
-  cartesian_topology(cartesian_topology const&& other) : super(other) {}
-  cartesian_topology& operator=(cartesian_topology const&& other) { 
-    (*this) = std::move(other.stl()); 
+  cartesian_topology(cartesian_topology&& other) : super(other) {}
+  cartesian_topology& operator=(cartesian_topology&& other) { 
+    stl().swap(other.stl());
     return *this;
   }
 

--- a/test/cartesian_topology_test.cpp
+++ b/test/cartesian_topology_test.cpp
@@ -182,6 +182,12 @@ int test_main(int argc, char* argv[])
     }
   }
   test_cartesian_topology( world, topo);
-
+#if !defined(BOOST_NO_CXX11_DEFAULTED_MOVES)
+  world.barrier();
+  if (world.rank()==0) {
+    std::cout << "Testing move constructor.\n";
+  }
+  test_cartesian_topology( world, std::move(topo));
+#endif
   return 0;
 }


### PR DESCRIPTION
Modify the signature of the move ctor to avoid infinite loop.
Test move ctor on cartesian topology.
refs #57