### PR TITLE
Fix jam py3

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -60,33 +60,13 @@ libraries += boost_mpi ;
 
   if [ python.configured ]
   {
-    py2-version = [ py-version 2 ] ;
-    py3-version = [ py-version 3 ] ;
-
-    # These library names are synchronized with those defined by Boost.Python, see libs/python/build/Jamfile.
-    lib_boost_python(2) = boost_python ;
-    lib_boost_python(3) = boost_python3 ;
-
-    lib_boost_python($(py2-version)) = $(lib_boost_python(2)) ;
-    lib_boost_python($(py3-version)) = $(lib_boost_python(3)) ;
-
-    lib_boost_mpi_python(2) = boost_mpi_python ;
-    lib_boost_mpi_python(3) = boost_mpi_python3 ;
-
-    lib_boost_mpi_python($(py2-version)) = $(lib_boost_mpi_python(2)) ;
-    lib_boost_mpi_python($(py3-version)) = $(lib_boost_mpi_python(3)) ;
-
-    for local N in 2 3
-    {
-        if $(py$(N)-version)
-        {
-            lib $(lib_boost_mpi_python($(py$(N)-version)))
+            lib boost_mpi_python
               : # Sources
                 python/serialize.cpp
               : # Requirements
                 <library>boost_mpi
                 <library>/mpi//mpi [ mpi.extra-requirements ]
-                <library>/boost/python//$(lib_boost_python($(py$(N)-version)))
+                <library>/boost/python//boost_python
                 <link>shared:<define>BOOST_MPI_DYN_LINK=1
                 <link>shared:<define>BOOST_MPI_PYTHON_DYN_LINK=1
                 <link>shared:<define>BOOST_PYTHON_DYN_LINK=1
@@ -94,7 +74,6 @@ libraries += boost_mpi ;
                 -<tag>@$(BOOST_JAMROOT_MODULE)%$(BOOST_JAMROOT_MODULE).tag
                 <tag>@$(BOOST_JAMROOT_MODULE)%$(BOOST_JAMROOT_MODULE).python-tag
                 <python-debugging>on:<define>BOOST_DEBUG_PYTHON
-                <python>$(py$(N)-version)
               : # Default build
                 <link>shared
               : # Usage requirements
@@ -116,8 +95,8 @@ libraries += boost_mpi ;
                 python/status.cpp
                 python/py_timer.cpp
               : # Requirements
-                <library>/boost/python//$(lib_boost_python($(py$(N)-version)))
-                <library>$(lib_boost_mpi_python($(py$(N)-version)))
+                <library>/boost/python//boost_python
+                <library>boost_mpi_python
                 <library>boost_mpi
                 <library>/mpi//mpi [ mpi.extra-requirements ]
                 <link>shared:<define>BOOST_MPI_DYN_LINK=1
@@ -125,16 +104,9 @@ libraries += boost_mpi ;
                 <link>shared:<define>BOOST_PYTHON_DYN_LINK=1
                 <link>shared <runtime-link>shared
                 <python-debugging>on:<define>BOOST_DEBUG_PYTHON
-                <python>$(py$(N)-version)
               ;
 
-            libraries += $(lib_boost_mpi_python($(py$(N)-version))) ;
-        }
-        else
-        {
-            alias $(lib_boost_mpi_python($(N))) ;
-        }
-    }
+            libraries += boost_mpi_python ;
   }
 }
 else if ! ( --without-mpi in  [ modules.peek : ARGV ] )


### PR DESCRIPTION
Just build mpi-python against current boost_python, not boostpython2|3

Looks like boost_python has moved on and stopped providing
boost_python2 and boost_python3 libraries. Possibly a regression in
boost_python, or possibly new world order which mpi should adapt to.

Fixes build: --with-python --with-mpi --python-buildid=py36 python=3.6