### PR TITLE
dangling pointer to custom operation in collectives

### DIFF
--- a/include/boost/mpi/collectives/all_reduce.hpp
+++ b/include/boost/mpi/collectives/all_reduce.hpp
@@ -51,7 +51,7 @@ namespace detail {
                   T* out_values, Op op, mpl::false_ /*is_mpi_op*/,
                   mpl::true_ /*is_mpi_datatype*/)
   {
-    user_op<Op, T> mpi_op(op);
+    user_op<Op, T> mpi_op;
     BOOST_MPI_CHECK_RESULT(MPI_Allreduce,
                            (const_cast<T*>(in_values), out_values, n,
                             boost::mpi::get_mpi_datatype<T>(*in_values),

--- a/include/boost/mpi/collectives/all_reduce.hpp
+++ b/include/boost/mpi/collectives/all_reduce.hpp
@@ -48,7 +48,7 @@ namespace detail {
   template<typename T, typename Op>
   void
   all_reduce_impl(const communicator& comm, const T* in_values, int n,
-                  T* out_values, Op op, mpl::false_ /*is_mpi_op*/,
+                  T* out_values, Op /* op */, mpl::false_ /*is_mpi_op*/,
                   mpl::true_ /*is_mpi_datatype*/)
   {
     user_op<Op, T> mpi_op;

--- a/include/boost/mpi/collectives/reduce.hpp
+++ b/include/boost/mpi/collectives/reduce.hpp
@@ -81,7 +81,7 @@ namespace detail {
               T* out_values, Op op, int root, mpl::false_ /*is_mpi_op*/,
               mpl::true_/*is_mpi_datatype*/)
   {
-    user_op<Op, T> mpi_op(op);
+    user_op<Op, T> mpi_op;
     BOOST_MPI_CHECK_RESULT(MPI_Reduce,
                            (const_cast<T*>(in_values), out_values, n,
                             boost::mpi::get_mpi_datatype<T>(*in_values),
@@ -96,7 +96,7 @@ namespace detail {
   reduce_impl(const communicator& comm, const T* in_values, int n, Op op,
               int root, mpl::false_/*is_mpi_op*/, mpl::true_/*is_mpi_datatype*/)
   {
-    user_op<Op, T> mpi_op(op);
+    user_op<Op, T> mpi_op;
     BOOST_MPI_CHECK_RESULT(MPI_Reduce,
                            (const_cast<T*>(in_values), 0, n,
                             boost::mpi::get_mpi_datatype<T>(*in_values),

--- a/include/boost/mpi/collectives/scan.hpp
+++ b/include/boost/mpi/collectives/scan.hpp
@@ -67,7 +67,7 @@ namespace detail {
   scan_impl(const communicator& comm, const T* in_values, int n, T* out_values,
             Op op, mpl::false_ /*is_mpi_op*/, mpl::true_ /*is_mpi_datatype*/)
   {
-    user_op<Op, T> mpi_op(op);
+    user_op<Op, T> mpi_op;
     BOOST_MPI_CHECK_RESULT(MPI_Scan,
                            (const_cast<T*>(in_values), out_values, n,
                             boost::mpi::get_mpi_datatype<T>(*in_values),

--- a/include/boost/mpi/operations.hpp
+++ b/include/boost/mpi/operations.hpp
@@ -292,14 +292,12 @@ namespace detail {
   class user_op
   {
   public:
-    explicit user_op(Op& op)
+    user_op()
     {
       BOOST_MPI_CHECK_RESULT(MPI_Op_create,
                              (&user_op<Op, T>::perform,
                               is_commutative<Op, T>::value,
                               &mpi_op));
-
-      op_ptr = &op;
     }
 
     ~user_op()
@@ -321,17 +319,15 @@ namespace detail {
 
   private:
     MPI_Op mpi_op;
-    static Op* op_ptr;
 
     static void BOOST_MPI_CALLING_CONVENTION perform(void* vinvec, void* voutvec, int* plen, MPI_Datatype*)
     {
       T* invec = static_cast<T*>(vinvec);
       T* outvec = static_cast<T*>(voutvec);
-      std::transform(invec, invec + *plen, outvec, outvec, *op_ptr);
+      Op op;
+      std::transform(invec, invec + *plen, outvec, outvec, op);
     }
   };
-
-  template<typename Op, typename T> Op* user_op<Op, T>::op_ptr = 0;
 
 } // end namespace detail
 


### PR DESCRIPTION
Try to make sure user's operators are stateless, and do not use their state if any.

refs #68