### PR TITLE
Use uncaught_exceptions from Boost.Core to avoid C++17 warnings

### DIFF
--- a/include/boost/mpi/operations.hpp
+++ b/include/boost/mpi/operations.hpp
@@ -23,7 +23,8 @@
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/and.hpp>
 #include <boost/mpi/datatype.hpp>
-#include <boost/utility/enable_if.hpp>
+#include <boost/core/enable_if.hpp>
+#include <boost/core/uncaught_exceptions.hpp>
 #include <functional>
 
 namespace boost { namespace mpi {
@@ -302,7 +303,7 @@ namespace detail {
 
     ~user_op()
     {
-      if (std::uncaught_exception()) {
+      if (boost::core::uncaught_exceptions() > 0) {
         // Ignore failure cases: there are obviously other problems
         // already, and we don't want to cause program termination if
         // MPI_Op_free fails.

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -8,6 +8,7 @@
 #include <boost/mpi/environment.hpp>
 #include <boost/mpi/exception.hpp>
 #include <boost/mpi/detail/mpi_datatype_cache.hpp>
+#include <boost/core/uncaught_exceptions.hpp>
 #include <cassert>
 #include <string>
 #include <exception>
@@ -137,7 +138,7 @@ environment::environment(int& argc, char** &argv, threading::level mt_level,
 environment::~environment()
 {
   if (i_initialized) {
-    if (std::uncaught_exception() && abort_on_exception) {
+    if (boost::core::uncaught_exceptions() > 0 && abort_on_exception) {
       abort(-1);
     } else if (!finalized()) {
       detail::mpi_datatype_cache().clear();


### PR DESCRIPTION
In C++17, `std::uncaught_exception` is deprecated in favor of `std::uncaught_exceptions`. Use portable `uncaught_exceptions` implementation from Boost.Core, which is also available for C++03.

This fixes gcc 8 warnings about using deprecated features in C++17 mode.
