### PR TITLE
mpi::detail::c_data needs to check for empty vectors

### DIFF
--- a/include/boost/mpi/detail/antiques.hpp
+++ b/include/boost/mpi/detail/antiques.hpp
@@ -19,10 +19,10 @@ namespace detail {
   // serve as an incentive to get rid of this when those compilers 
   // are dropped.
   template <typename T, typename A>
-  T* c_data(std::vector<T,A>& v) { return &(v[0]); }
+  T* c_data(std::vector<T,A>& v) { if (v.empty()) return NULL; return &(v[0]); }
 
   template <typename T, typename A>
-  T const* c_data(std::vector<T,A> const& v) { return &(v[0]); }
+  T const* c_data(std::vector<T,A> const& v) { if (v.empty()) return NULL; return &(v[0]); }
 
   // Some old MPI implementation (OpenMPI 1.6 for example) have non 
   // conforming API w.r.t. constness.


### PR DESCRIPTION
If the standard library is configured to do range checks (`-D_GLIBCXX_ASSERTIONS`), accessing the zeroth element of a vector to get its address triggers an assertion.

This issue was discovered in https://github.com/espressomd/espresso/issues/2507, where `boost::mpi::detail::dispatch_scatter_sendbuf` runs into it.