### PR TITLE
Recognize std::plus<void> and similar as mpi ops

### DIFF
--- a/include/boost/mpi/operations.hpp
+++ b/include/boost/mpi/operations.hpp
@@ -213,40 +213,50 @@ struct is_mpi_op<minimum<T>, T>
   static MPI_Op op() { return MPI_MIN; }
 };
 
+namespace detail {
+  template<typename T, typename U>
+  struct is_same_or_void : public boost::mpl::or_<boost::mpl::is_same<T, U>,
+                                                  boost::mpl::is_same<U, void>> { };
+}
+
 /// INTERNAL ONLY
-template<typename T>
- struct is_mpi_op<std::plus<T>, T>
-  : public boost::mpl::or_<is_mpi_integer_datatype<T>,
-                           is_mpi_floating_point_datatype<T>,
-                           is_mpi_complex_datatype<T> >
+template<typename T, typename U>
+ struct is_mpi_op<std::plus<U>, T>
+  : public boost::mpl::and_<detail::is_same_or_void<T, U>,
+                            boost::mpl::or_<is_mpi_integer_datatype<T>,
+                                            is_mpi_floating_point_datatype<T>,
+                                            is_mpi_complex_datatype<T> > >
 {
   static MPI_Op op() { return MPI_SUM; }
 };
 
 /// INTERNAL ONLY
-template<typename T>
- struct is_mpi_op<std::multiplies<T>, T>
-  : public boost::mpl::or_<is_mpi_integer_datatype<T>,
-                           is_mpi_floating_point_datatype<T>,
-                           is_mpi_complex_datatype<T> >
+template<typename T, typename U>
+struct is_mpi_op<std::multiplies<U>, T>
+  : public boost::mpl::and_<detail::is_same_or_void<T, U>,
+                            boost::mpl::or_<is_mpi_integer_datatype<T>,
+                                            is_mpi_floating_point_datatype<T>,
+                                            is_mpi_complex_datatype<T> > >
 {
   static MPI_Op op() { return MPI_PROD; }
 };
 
 /// INTERNAL ONLY
-template<typename T>
- struct is_mpi_op<std::logical_and<T>, T>
-  : public boost::mpl::or_<is_mpi_integer_datatype<T>,
-                           is_mpi_logical_datatype<T> >
+template<typename T, typename U>
+ struct is_mpi_op<std::logical_and<U>, T>
+  : public boost::mpl::and_<detail::is_same_or_void<T, U>,
+                            boost::mpl::or_<is_mpi_integer_datatype<T>,
+                                            is_mpi_logical_datatype<T> > >
 {
   static MPI_Op op() { return MPI_LAND; }
 };
 
 /// INTERNAL ONLY
-template<typename T>
- struct is_mpi_op<std::logical_or<T>, T>
-  : public boost::mpl::or_<is_mpi_integer_datatype<T>,
-                           is_mpi_logical_datatype<T> >
+template<typename T, typename U>
+ struct is_mpi_op<std::logical_or<U>, T>
+  : public boost::mpl::and_<detail::is_same_or_void<T, U>,
+                            boost::mpl::or_<is_mpi_integer_datatype<T>,
+                                            is_mpi_logical_datatype<T> > >
 {
   static MPI_Op op() { return MPI_LOR; }
 };

--- a/test/is_mpi_op_test.cpp
+++ b/test/is_mpi_op_test.cpp
@@ -32,10 +32,14 @@ BOOST_AUTO_TEST_CASE(mpi_basic_op)
   test_op<minimum<float>, float>(MPI_MIN);
   BOOST_TEST((is_mpi_op<minimum<float>, float>::op() == MPI_MIN));
   BOOST_TEST((is_mpi_op<plus<double>, double>::op() == MPI_SUM));
+  BOOST_TEST((is_mpi_op<plus<void>, double>::op() == MPI_SUM));
   BOOST_TEST((is_mpi_op<multiplies<long>, long>::op() == MPI_PROD));
+  BOOST_TEST((is_mpi_op<multiplies<void>, long>::op() == MPI_PROD));
   BOOST_TEST((is_mpi_op<logical_and<int>, int>::op() == MPI_LAND));
+  BOOST_TEST((is_mpi_op<logical_and<void>, int>::op() == MPI_LAND));
   BOOST_TEST((is_mpi_op<bitwise_and<int>, int>::op() == MPI_BAND));
   BOOST_TEST((is_mpi_op<logical_or<int>, int>::op() == MPI_LOR));
+  BOOST_TEST((is_mpi_op<logical_or<void>, int>::op() == MPI_LOR));
   BOOST_TEST((is_mpi_op<bitwise_or<int>, int>::op() == MPI_BOR));
   BOOST_TEST((is_mpi_op<logical_xor<int>, int>::op() == MPI_LXOR));
   BOOST_TEST((is_mpi_op<bitwise_xor<int>, int>::op() == MPI_BXOR));


### PR DESCRIPTION
C++14 introduces `std::plus<void>` and similar functors, that determine the type by argument type deduction on the operator (so that you don't have to specify the type). This adds overloads to recognize those as native mpi ops.