### PR TITLE
Add MPI Python libs to install target

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -73,6 +73,7 @@ rule python-tag ( name : type ? : property-set )
     return  [ tag $(result) : $(type) : $(property-set) ] ;
 }
 
+mpi_python_libs = ;
 
 if [ mpi.configured ]
 {
@@ -168,6 +169,8 @@ lib boost_mpi
                 <link>shared <runtime-link>shared
                 <python-debugging>on:<define>BOOST_DEBUG_PYTHON
               ;
+
+            mpi_python_libs = boost_mpi_python mpi ;
   }
 }
 else if ! ( --without-mpi in  [ modules.peek : ARGV ] )
@@ -184,4 +187,4 @@ else
   alias boost_mpi ;
 }
 
-boost-install boost_mpi ;
+boost-install boost_mpi $(mpi_python_libs) ;


### PR DESCRIPTION
This fixes mpi plugins for Python not being built and installed.