### PR TITLE
Waitall: Handle null (default constructed) requests

### DIFF
--- a/include/boost/mpi/nonblocking.hpp
+++ b/include/boost/mpi/nonblocking.hpp
@@ -194,7 +194,10 @@ wait_all(ForwardIterator first, ForwardIterator last, OutputIterator out)
     difference_type idx = 0;
     for (ForwardIterator current = first; current != last; ++current, ++idx) {
       if (!completed[idx]) {
-        if (optional<status> stat = current->test()) {
+        if (!current->active()) {
+          completed[idx] = true;
+          --num_outstanding_requests;
+        } else if (optional<status> stat = current->test()) {
           // This outstanding request has been completed. We're done.
           results[idx] = *stat;
           completed[idx] = true;
@@ -263,7 +266,10 @@ wait_all(ForwardIterator first, ForwardIterator last)
     difference_type idx = 0;
     for (ForwardIterator current = first; current != last; ++current, ++idx) {
       if (!completed[idx]) {
-        if (optional<status> stat = current->test()) {
+        if (!current->active()) {
+          completed[idx] = true;
+          --num_outstanding_requests;
+        } else if (optional<status> stat = current->test()) {
           // This outstanding request has been completed.
           completed[idx] = true;
           --num_outstanding_requests;


### PR DESCRIPTION
Analogously to MPI_REQUEST_NULL being the neutral element to MPI_Wait(), a null request should gracefully be handled also by wait_all.

Currently (boost 1.73) this deadlocks:
```c++
#include <boost/mpi.hpp>
#include <boost/mpi/nonblocking.hpp>
#include <vector>


int main()
{
	boost::mpi::environment env;
	std::vector<boost::mpi::request> req(1);
	boost::mpi::wait_all(req.begin(), req.end());
}
```
(You may add this or derivatives of it as a test case under the boost license.)

This PR fixes this issue by treating inactive requests as completed.