### PR TITLE
Avoid access of front element in empty vectors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,16 @@ matrix:
   include:
     - os: linux
       compiler: g++
-      env: TOOLSET=gcc COMPILER=g++ CXXSTD=03,11
+      env: TOOLSET=gcc COMPILER=g++ CXXSTD=03
+      addons:
+        apt:
+          packages:
+            - libopenmpi-dev
+            - openmpi-bin
+
+    - os: linux
+      compiler: g++
+      env: TOOLSET=gcc COMPILER=g++ CXXSTD=11
       addons:
         apt:
           packages:
@@ -35,7 +44,7 @@ matrix:
 
     - os: linux
       compiler: g++-4.4
-      env: TOOLSET=gcc COMPILER=g++-4.4 CXXSTD=98,0x
+      env: TOOLSET=gcc COMPILER=g++-4.4 CXXSTD=98
       addons:
         apt:
           packages:
@@ -46,8 +55,33 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - os: linux
+      compiler: g++-4.4
+      env: TOOLSET=gcc COMPILER=g++-4.4 CXXSTD=0x
+      addons:
+        apt:
+          packages:
+            - g++-4.4
+            - libopenmpi-dev
+            - openmpi-bin
+          sources:
+            - ubuntu-toolchain-r-test
+
+
+    - os: linux
       compiler: g++-4.6
-      env: TOOLSET=gcc COMPILER=g++-4.6 CXXSTD=03,0x
+      env: TOOLSET=gcc COMPILER=g++-4.6 CXXSTD=03
+      addons:
+        apt:
+          packages:
+            - g++-4.6
+            - libopenmpi-dev
+            - openmpi-bin
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      compiler: g++-4.6
+      env: TOOLSET=gcc COMPILER=g++-4.6 CXXSTD=0x
       addons:
         apt:
           packages:
@@ -59,7 +93,19 @@ matrix:
 
     - os: linux
       compiler: g++-5
-      env: TOOLSET=gcc COMPILER=g++-5 CXXSTD=11,14
+      env: TOOLSET=gcc COMPILER=g++-5 CXXSTD=11
+      addons:
+        apt:
+          packages:
+            - g++-5
+            - libopenmpi-dev
+            - openmpi-bin
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      compiler: g++-5
+      env: TOOLSET=gcc COMPILER=g++-5 CXXSTD=14
       addons:
         apt:
           packages:
@@ -71,7 +117,19 @@ matrix:
 
     - os: linux
       compiler: g++-6
-      env: TOOLSET=gcc COMPILER=g++-6 CXXSTD=11,14
+      env: TOOLSET=gcc COMPILER=g++-6 CXXSTD=11
+      addons:
+        apt:
+          packages:
+            - g++-6
+            - libopenmpi-dev
+            - openmpi-bin
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      compiler: g++-6
+      env: TOOLSET=gcc COMPILER=g++-6 CXXSTD=14
       addons:
         apt:
           packages:
@@ -83,7 +141,19 @@ matrix:
 
     - os: linux
       compiler: g++-7
-      env: TOOLSET=gcc COMPILER=g++-7 CXXSTD=14,17
+      env: TOOLSET=gcc COMPILER=g++-7 CXXSTD=14
+      addons:
+        apt:
+          packages:
+            - g++-7
+            - libopenmpi-dev
+            - openmpi-bin
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      compiler: g++-7
+      env: TOOLSET=gcc COMPILER=g++-7 CXXSTD=17
       addons:
         apt:
           packages:
@@ -95,7 +165,19 @@ matrix:
 
     - os: linux
       compiler: g++-8
-      env: TOOLSET=gcc COMPILER=g++-8 CXXSTD=14,17
+      env: TOOLSET=gcc COMPILER=g++-8 CXXSTD=14
+      addons:
+        apt:
+          packages:
+            - g++-8
+            - libopenmpi-dev
+            - openmpi-bin
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      compiler: g++-8
+      env: TOOLSET=gcc COMPILER=g++-8 CXXSTD=17
       addons:
         apt:
           packages:
@@ -107,7 +189,34 @@ matrix:
 
     - os: linux
       compiler: clang++
-      env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,14,1z
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=03
+      addons:
+        apt:
+          packages:
+            - libopenmpi-dev
+            - openmpi-bin
+
+    - os: linux
+      compiler: clang++
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=11
+      addons:
+        apt:
+          packages:
+            - libopenmpi-dev
+            - openmpi-bin
+
+    - os: linux
+      compiler: clang++
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=14
+      addons:
+        apt:
+          packages:
+            - libopenmpi-dev
+            - openmpi-bin
+
+    - os: linux
+      compiler: clang++
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=1z
       addons:
         apt:
           packages:
@@ -116,7 +225,37 @@ matrix:
 
     - os: linux
       compiler: clang++-libc++
-      env: TOOLSET=clang COMPILER=clang++-libc++ CXXSTD=03,11,14,1z
+      env: TOOLSET=clang COMPILER=clang++-libc++ CXXSTD=03
+      addons:
+        apt:
+          packages:
+            - libc++-dev
+            - libopenmpi-dev
+            - openmpi-bin
+
+    - os: linux
+      compiler: clang++-libc++
+      env: TOOLSET=clang COMPILER=clang++-libc++ CXXSTD=11
+      addons:
+        apt:
+          packages:
+            - libc++-dev
+            - libopenmpi-dev
+            - openmpi-bin
+
+    - os: linux
+      compiler: clang++-libc++
+      env: TOOLSET=clang COMPILER=clang++-libc++ CXXSTD=14
+      addons:
+        apt:
+          packages:
+            - libc++-dev
+            - libopenmpi-dev
+            - openmpi-bin
+
+    - os: linux
+      compiler: clang++-libc++
+      env: TOOLSET=clang COMPILER=clang++-libc++ CXXSTD=1z
       addons:
         apt:
           packages:

--- a/include/boost/mpi/collectives/all_reduce.hpp
+++ b/include/boost/mpi/collectives/all_reduce.hpp
@@ -77,7 +77,7 @@ namespace detail {
       // implementation in this case.
       // it's not clear how/if we can avoid the copy.
       std::vector<T> tmp_in( out_values, out_values + n);
-      reduce(comm, &(tmp_in[0]), n, out_values, op, 0);
+      reduce(comm, detail::c_data(tmp_in), n, out_values, op, 0);
     } else {
       reduce(comm, in_values, n, out_values, op, 0);
     }

--- a/include/boost/mpi/collectives/all_to_all.hpp
+++ b/include/boost/mpi/collectives/all_to_all.hpp
@@ -91,10 +91,10 @@ namespace detail {
 
     // Transmit the actual data
     BOOST_MPI_CHECK_RESULT(MPI_Alltoallv,
-                           (&outgoing[0], &send_sizes[0],
-                            &send_disps[0], MPI_PACKED,
-                            &incoming[0], &recv_sizes[0],
-                            &recv_disps[0], MPI_PACKED,
+                           (detail::c_data(outgoing), detail::c_data(send_sizes),
+                            detail::c_data(send_disps), MPI_PACKED,
+                            detail::c_data(incoming), detail::c_data(recv_sizes),
+                            detail::c_data(recv_disps), MPI_PACKED,
                             comm));
 
     // Deserialize data from the iarchive
@@ -126,7 +126,7 @@ all_to_all(const communicator& comm, const std::vector<T>& in_values,
 {
   BOOST_ASSERT((int)in_values.size() == comm.size());
   out_values.resize(comm.size());
-  ::boost::mpi::all_to_all(comm, &in_values[0], &out_values[0]);
+  ::boost::mpi::all_to_all(comm, detail::c_data(in_values), detail::c_data(out_values));
 }
 
 template<typename T>
@@ -143,7 +143,7 @@ all_to_all(const communicator& comm, const std::vector<T>& in_values, int n,
 {
   BOOST_ASSERT((int)in_values.size() == comm.size() * n);
   out_values.resize(comm.size() * n);
-  ::boost::mpi::all_to_all(comm, &in_values[0], n, &out_values[0]);
+  ::boost::mpi::all_to_all(comm, detail::c_data(in_values), n, detail::c_data(out_values));
 }
 
 } } // end namespace boost::mpi

--- a/include/boost/mpi/collectives/gatherv.hpp
+++ b/include/boost/mpi/collectives/gatherv.hpp
@@ -87,7 +87,7 @@ gatherv(const communicator& comm, const T* in_values, int in_size,
 {
   if (comm.rank() == root)
     detail::gatherv_impl(comm, in_values, in_size,
-                         out_values, &sizes[0], &displs[0],
+                         out_values, detail::c_data(sizes), detail::c_data(displs),
                          root, is_mpi_datatype<T>());
   else
     detail::gatherv_impl(comm, in_values, in_size, root, is_mpi_datatype<T>());
@@ -99,7 +99,7 @@ gatherv(const communicator& comm, const std::vector<T>& in_values,
         T* out_values, const std::vector<int>& sizes, const std::vector<int>& displs,
         int root)
 {
-  ::boost::mpi::gatherv(comm, &in_values[0], in_values.size(), out_values, sizes, displs, root);
+  ::boost::mpi::gatherv(comm, detail::c_data(in_values), in_values.size(), out_values, sizes, displs, root);
 }
 
 template<typename T>
@@ -113,7 +113,7 @@ template<typename T>
 void gatherv(const communicator& comm, const std::vector<T>& in_values, int root)
 {
   BOOST_ASSERT(comm.rank() != root);
-  detail::gatherv_impl(comm, &in_values[0], in_values.size(), root, is_mpi_datatype<T>());
+  detail::gatherv_impl(comm, detail::c_data(in_values), in_values.size(), root, is_mpi_datatype<T>());
 }
 
 ///////////////////////
@@ -139,7 +139,7 @@ void
 gatherv(const communicator& comm, const std::vector<T>& in_values,
         T* out_values, const std::vector<int>& sizes, int root)
 {
-  ::boost::mpi::gatherv(comm, &in_values[0], in_values.size(), out_values, sizes, root);
+  ::boost::mpi::gatherv(comm, detail::c_data(in_values), in_values.size(), out_values, sizes, root);
 }
 
 } } // end namespace boost::mpi

--- a/include/boost/mpi/collectives/reduce.hpp
+++ b/include/boost/mpi/collectives/reduce.hpp
@@ -335,7 +335,7 @@ void
 reduce(const communicator & comm, std::vector<T> const & in_values, Op op,
        int root)
 {
-  reduce(comm, &in_values.front(), in_values.size(), op, root);
+  reduce(comm, detail::c_data(in_values), in_values.size(), op, root);
 }
 
 template<typename T, typename Op>
@@ -344,7 +344,7 @@ reduce(const communicator & comm, std::vector<T> const & in_values,
        std::vector<T> & out_values, Op op, int root)
 {
   if (root == comm.rank()) out_values.resize(in_values.size());
-  reduce(comm, &in_values.front(), in_values.size(), &out_values.front(), op,
+  reduce(comm, detail::c_data(in_values), in_values.size(), detail::c_data(out_values), op,
          root);
 }
 

--- a/include/boost/mpi/collectives/scatter.hpp
+++ b/include/boost/mpi/collectives/scatter.hpp
@@ -188,7 +188,7 @@ void
 scatter(const communicator& comm, const std::vector<T>& in_values, 
         T* out_values, int n, int root)
 {
-  ::boost::mpi::scatter(comm, &in_values[0], out_values, n, root);
+  ::boost::mpi::scatter(comm, detail::c_data(in_values), out_values, n, root);
 }
 
 template<typename T>

--- a/include/boost/mpi/collectives/scatterv.hpp
+++ b/include/boost/mpi/collectives/scatterv.hpp
@@ -142,7 +142,7 @@ void
 scatterv(const communicator& comm, const std::vector<T>& in_values,
          const std::vector<int>& sizes, T* out_values, int root)
 {
-  ::boost::mpi::scatterv(comm, &in_values[0], sizes, out_values, root);
+  ::boost::mpi::scatterv(comm, detail::c_data(in_values), sizes, out_values, root);
 }
 
 template<typename T>
@@ -159,7 +159,7 @@ void
 scatterv(const communicator& comm, const std::vector<T>& in_values,
          T* out_values, int out_size, int root)
 {
-  ::boost::mpi::scatterv(comm, &in_values[0], out_values, out_size, root);
+  ::boost::mpi::scatterv(comm, detail::c_data(in_values), out_values, out_size, root);
 }
 
 } } // end namespace boost::mpi

--- a/include/boost/mpi/detail/binary_buffer_iprimitive.hpp
+++ b/include/boost/mpi/detail/binary_buffer_iprimitive.hpp
@@ -41,12 +41,12 @@ public:
 
     void* address ()
     {
-      return &buffer_.front();
+      return detail::c_data(buffer_);
     }
 
     void const* address () const
     {
-      return &buffer_.front();
+      return detail::c_data(buffer_);
     }
 
     const std::size_t& size() const

--- a/include/boost/mpi/detail/binary_buffer_oprimitive.hpp
+++ b/include/boost/mpi/detail/binary_buffer_oprimitive.hpp
@@ -40,7 +40,7 @@ public:
 
     void const * address() const
     {
-      return &buffer_.front();
+      return detail::c_data(buffer_);
     }
 
     const std::size_t& size() const

--- a/include/boost/mpi/detail/mpi_datatype_primitive.hpp
+++ b/include/boost/mpi/detail/mpi_datatype_primitive.hpp
@@ -133,7 +133,7 @@ private:
     template <class T>
     static T* get_data(std::vector<T>& v)
     {
-      return v.empty() ? 0 : &(v[0]);
+      return detail::c_data(v);
     }
 
     std::vector<MPI_Aint> addresses;

--- a/include/boost/mpi/detail/packed_iprimitive.hpp
+++ b/include/boost/mpi/detail/packed_iprimitive.hpp
@@ -39,12 +39,12 @@ public:
 
     void* address ()
     {
-      return &buffer_[0];
+      return detail::c_data(buffer_);
     }
 
     void const* address () const
     {
-      return &buffer_[0];
+      return detail::c_data(buffer_);
     }
 
     const std::size_t& size() const

--- a/include/boost/mpi/detail/packed_oprimitive.hpp
+++ b/include/boost/mpi/detail/packed_oprimitive.hpp
@@ -38,7 +38,7 @@ public:
 
     void const * address() const
     {
-      return &buffer_[0];
+      return detail::c_data(buffer_);
     }
 
     const std::size_t& size() const
@@ -114,7 +114,7 @@ private:
 
     static buffer_type::value_type* get_data(buffer_type& b)
     {
-      return b.empty() ? 0 : &(b[0]);
+      return detail::c_data(b);
     }
 
   buffer_type& buffer_;

--- a/include/boost/mpi/detail/request_handlers.hpp
+++ b/include/boost/mpi/detail/request_handlers.hpp
@@ -456,7 +456,7 @@ public:
       // Resize our buffer and get ready to receive its data
       this->extra::m_values.resize(this->extra::m_count);
       BOOST_MPI_CHECK_RESULT(MPI_Irecv,
-                             (&(this->extra::m_values[0]), this->extra::m_values.size(), get_mpi_datatype<T>(),
+                             (detail::c_data(this->extra::m_values), this->extra::m_values.size(), get_mpi_datatype<T>(),
                               stat.source(), stat.tag(), 
                               MPI_Comm(m_comm), m_requests + 1));
     }
@@ -478,7 +478,7 @@ public:
         // Resize our buffer and get ready to receive its data
         this->extra::m_values.resize(this->extra::m_count);
         BOOST_MPI_CHECK_RESULT(MPI_Irecv,
-                               (&(this->extra::m_values[0]), this->extra::m_values.size(), get_mpi_datatype<T>(),
+                               (detail::c_data(this->extra::m_values), this->extra::m_values.size(), get_mpi_datatype<T>(),
                                 stat.source(), stat.tag(), 
                                 MPI_Comm(m_comm), m_requests + 1));
       } else

--- a/include/boost/mpi/graph_communicator.hpp
+++ b/include/boost/mpi/graph_communicator.hpp
@@ -235,8 +235,8 @@ graph_communicator::setup_graph(const communicator& comm, const Graph& graph,
   BOOST_MPI_CHECK_RESULT(MPI_Graph_create,
                          ((MPI_Comm)comm, 
                           nvertices,
-                          &indices[0],
-                          edges.empty()? (int*)0 : &edges[0],
+                          detail::c_data(indices),
+                          detail::c_data(edges),
                           reorder,
                           &newcomm));
   this->comm_ptr.reset(new MPI_Comm(newcomm), comm_free());

--- a/include/boost/mpi/group.hpp
+++ b/include/boost/mpi/group.hpp
@@ -16,6 +16,7 @@
 #define BOOST_MPI_GROUP_HPP
 
 #include <boost/mpi/exception.hpp>
+#include <boost/mpi/detail/antiques.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/optional.hpp>
 #include <vector>
@@ -272,9 +273,9 @@ group::translate_ranks(InputIterator first, InputIterator last,
   BOOST_MPI_CHECK_RESULT(MPI_Group_translate_ranks,
                          ((MPI_Group)*this,
                           in_array.size(),
-                          &in_array[0],
+                          detail::c_data(in_array),
                           (MPI_Group)to_group,
-                          &out_array[0]));
+                          detail::c_data(out_array)));
 
   for (std::vector<int>::size_type i = 0, n = out_array.size(); i < n; ++i)
     *out++ = out_array[i];
@@ -300,7 +301,7 @@ group group::include(InputIterator first, InputIterator last)
   std::vector<int> ranks(first, last);
   MPI_Group result;
   BOOST_MPI_CHECK_RESULT(MPI_Group_incl,
-                         ((MPI_Group)*this, ranks.size(), &ranks[0], &result));
+                         ((MPI_Group)*this, ranks.size(), detail::c_data(ranks), &result));
   return group(result, /*adopt=*/true);
 }
 
@@ -322,7 +323,7 @@ group group::exclude(InputIterator first, InputIterator last)
   std::vector<int> ranks(first, last);
   MPI_Group result;
   BOOST_MPI_CHECK_RESULT(MPI_Group_excl,
-                         ((MPI_Group)*this, ranks.size(), &ranks[0], &result));
+                         ((MPI_Group)*this, ranks.size(), detail::c_data(ranks), &result));
   return group(result, /*adopt=*/true);
 }
 

--- a/include/boost/mpi/nonblocking.hpp
+++ b/include/boost/mpi/nonblocking.hpp
@@ -91,7 +91,7 @@ wait_any(ForwardIterator first, ForwardIterator last)
         int index;
         status stat;
         BOOST_MPI_CHECK_RESULT(MPI_Waitany, 
-                               (n, &requests[0], &index, &stat.m_status));
+                               (n, detail::c_data(requests), &index, &stat.m_status));
 
         // We don't have a notion of empty requests or status objects,
         // so this is an error.
@@ -222,8 +222,8 @@ wait_all(ForwardIterator first, ForwardIterator last, OutputIterator out)
       // Let MPI wait until all of these operations completes.
       std::vector<MPI_Status> stats(num_outstanding_requests);
       BOOST_MPI_CHECK_RESULT(MPI_Waitall, 
-                             (num_outstanding_requests, &requests[0], 
-                              &stats[0]));
+                             (num_outstanding_requests, detail::c_data(requests), 
+                              detail::c_data(stats)));
 
       for (std::vector<MPI_Status>::iterator i = stats.begin(); 
            i != stats.end(); ++i, ++out) {
@@ -289,7 +289,7 @@ wait_all(ForwardIterator first, ForwardIterator last)
 
       // Let MPI wait until all of these operations completes.
       BOOST_MPI_CHECK_RESULT(MPI_Waitall, 
-                             (num_outstanding_requests, &requests[0], 
+                             (num_outstanding_requests, detail::c_data(requests), 
                               MPI_STATUSES_IGNORE));
 
       // Signal completion
@@ -346,7 +346,7 @@ test_all(ForwardIterator first, ForwardIterator last, OutputIterator out)
   int flag = 0;
   int n = requests.size();
   std::vector<MPI_Status> stats(n);
-  BOOST_MPI_CHECK_RESULT(MPI_Testall, (n, &requests[0], &flag, &stats[0]));
+  BOOST_MPI_CHECK_RESULT(MPI_Testall, (n, detail::c_data(requests), &flag, detail::c_data(stats)));
   if (flag) {
     for (int i = 0; i < n; ++i, ++out) {
       status stat;
@@ -379,7 +379,7 @@ test_all(ForwardIterator first, ForwardIterator last)
   int flag = 0;
   int n = requests.size();
   BOOST_MPI_CHECK_RESULT(MPI_Testall, 
-                         (n, &requests[0], &flag, MPI_STATUSES_IGNORE));
+                         (n, detail::c_data(requests), &flag, MPI_STATUSES_IGNORE));
   return flag != 0;
 }
 
@@ -483,8 +483,8 @@ wait_some(BidirectionalIterator first, BidirectionalIterator last,
         // Let MPI wait until some of these operations complete.
         int num_completed;
         BOOST_MPI_CHECK_RESULT(MPI_Waitsome, 
-                               (n, &requests[0], &num_completed, &indices[0],
-                                &stats[0]));
+                               (n, detail::c_data(requests), &num_completed, detail::c_data(indices),
+                                detail::c_data(stats)));
 
         // Translate the index-based result of MPI_Waitsome into a
         // partitioning on the requests.
@@ -591,7 +591,7 @@ wait_some(BidirectionalIterator first, BidirectionalIterator last)
         // Let MPI wait until some of these operations complete.
         int num_completed;
         BOOST_MPI_CHECK_RESULT(MPI_Waitsome, 
-                               (n, &requests[0], &num_completed, &indices[0],
+                               (n, detail::c_data(requests), &num_completed, detail::c_data(indices),
                                 MPI_STATUSES_IGNORE));
 
         // Translate the index-based result of MPI_Waitsome into a

--- a/src/cartesian_communicator.cpp
+++ b/src/cartesian_communicator.cpp
@@ -14,11 +14,6 @@
 
 namespace boost { namespace mpi {
 
-namespace {
-  template <typename T, typename A>
-  T* c_data(std::vector<T,A>& v) { return c_data(v); }
-}
-
 std::ostream&
 operator<<(std::ostream& out, cartesian_dimension const& d) {
   out << '(' << d.size << ',';
@@ -64,7 +59,7 @@ cartesian_communicator::cartesian_communicator(const communicator&         comm,
   MPI_Comm newcomm;
   BOOST_MPI_CHECK_RESULT(MPI_Cart_create, 
                          ((MPI_Comm)comm, dims.size(),
-                          c_data(dims), c_data(periodic),
+                          detail::c_data(dims), detail::c_data(periodic),
                           int(reorder), &newcomm));
   if(newcomm != MPI_COMM_NULL) {
     comm_ptr.reset(new MPI_Comm(newcomm), comm_free());
@@ -86,7 +81,7 @@ cartesian_communicator::cartesian_communicator(const cartesian_communicator& com
   
   MPI_Comm newcomm;
   BOOST_MPI_CHECK_RESULT(MPI_Cart_sub, 
-                         ((MPI_Comm)comm, c_data(bitset), &newcomm));
+                         ((MPI_Comm)comm, detail::c_data(bitset), &newcomm));
   if(newcomm != MPI_COMM_NULL) {
     comm_ptr.reset(new MPI_Comm(newcomm), comm_free());
   }
@@ -105,7 +100,7 @@ cartesian_communicator::rank(const std::vector<int>& coords ) const {
   int r = -1;
   assert(int(coords.size()) == ndims());
   BOOST_MPI_CHECK_RESULT(MPI_Cart_rank, 
-                         (MPI_Comm(*this), c_data(const_cast<std::vector<int>&>(coords)), 
+                         (MPI_Comm(*this), detail::c_data(const_cast<std::vector<int>&>(coords)), 
                           &r));
   return r;
 }
@@ -123,7 +118,7 @@ std::vector<int>
 cartesian_communicator::coordinates(int rk) const {
   std::vector<int> cbuf(ndims());
   BOOST_MPI_CHECK_RESULT(MPI_Cart_coords, 
-                         (MPI_Comm(*this), rk, cbuf.size(), c_data(cbuf) ));
+                         (MPI_Comm(*this), rk, cbuf.size(), detail::c_data(cbuf) ));
   return cbuf;
 }
 
@@ -136,7 +131,7 @@ cartesian_communicator::topology(  cartesian_topology&  topo,
   std::vector<int> cdims(ndims);
   std::vector<int> cperiods(ndims);
   BOOST_MPI_CHECK_RESULT(MPI_Cart_get,
-                         (MPI_Comm(*this), ndims, c_data(cdims), c_data(cperiods), c_data(coords)));
+                         (MPI_Comm(*this), ndims, detail::c_data(cdims), detail::c_data(cperiods), detail::c_data(coords)));
   cartesian_topology res(cdims.begin(), cperiods.begin(), ndims);
   topo.swap(res);
 }
@@ -173,7 +168,7 @@ cartesian_dimensions(int sz, std::vector<int>&  dims) {
   int leftover = sz % min;
   
   BOOST_MPI_CHECK_RESULT(MPI_Dims_create,
-                         (sz-leftover, dims.size(), c_data(dims)));
+                         (sz-leftover, dims.size(), detail::c_data(dims)));
   return dims;
 }
 

--- a/src/cartesian_communicator.cpp
+++ b/src/cartesian_communicator.cpp
@@ -10,12 +10,13 @@
 #include <cassert>
 
 #include <boost/mpi/cartesian_communicator.hpp>
+#include <boost/mpi/detail/antiques.hpp>
 
 namespace boost { namespace mpi {
 
 namespace {
   template <typename T, typename A>
-  T* c_data(std::vector<T,A>& v) { return &(v[0]); }
+  T* c_data(std::vector<T,A>& v) { return c_data(v); }
 }
 
 std::ostream&

--- a/test/block_nonblock_test.cpp
+++ b/test/block_nonblock_test.cpp
@@ -82,7 +82,12 @@ BOOST_AUTO_TEST_CASE(non_blocking)
     fmt << "S" << i;
     strings[i] = fmt.str();
   }
-  
+
+  std::vector<int> empty;
+
+  BOOST_CHECK(test(world, empty, false, true));
+  BOOST_CHECK(test(world, empty, false, false));
+
   BOOST_CHECK(test(world, integers, true,  true));
   BOOST_CHECK(test(world, integers, true,  false));
   BOOST_CHECK(test(world, strings, true,  true));


### PR DESCRIPTION
There are multiple places in the library where a pointer to the memory managed by a vector by taking the address of the first element. This leads to undefined behavior if the vector is empty (eg there is no first element), which has caused problems downstream. For example some standard libraries have asserts for this. This patch is a modified version of a patch created by @mkuron which switches all the places that we found to `detail::c_data`, which already existed in the library.

(Please note that not all of the replacements are needed because in some places the vector can not
be empty, but I find the function call also more idiomatic and readable, and easier to replace when support for C++03 is dropped)