### PR TITLE
Fix build boost_mpi_python on Windows

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -77,6 +77,7 @@ lib boost_mpi
               : # Requirements
                 <library>boost_mpi
                 <library>/mpi//mpi [ mpi.extra-requirements ]
+                <library>/python//python_for_extensions
                 <library>/boost/python//boost_python
                 <link>shared:<define>BOOST_MPI_DYN_LINK=1
                 <link>shared:<define>BOOST_MPI_PYTHON_DYN_LINK=1


### PR DESCRIPTION
On Windows, all code using Python has to link to the Python import library.

`python_for_extensions` is a target defined by Boost.Build to provide the Python include paths, and on Windows, the Python import library, as usage requirements.