### PR TITLE
PEP 328 import

### DIFF
--- a/build/__init__.py
+++ b/build/__init__.py
@@ -1,10 +1,12 @@
+from __future__ import absolute_import
+
 import sys
 if sys.platform == 'linux2':
     import DLFCN as dl
     flags = sys.getdlopenflags()
     sys.setdlopenflags(dl.RTLD_NOW|dl.RTLD_GLOBAL)
-    import mpi
+    from . import mpi
     sys.setdlopenflags(flags)
 else:
-    import mpi
+    from . import mpi
 


### PR DESCRIPTION
Hi @aminiussi 
we have been carrying this patch in Gentoo for ages, and would like to upstream it. The current import statements are still from the Python 2/pre-PEP328 days. In Gentoo, the Boost.MPI python layout looks like:
```
$ tree /usr/lib/python3.11/site-packages/boost/
/usr/lib/python3.11/site-packages/boost/
├── __init__.py
├── __pycache__
│   ├── __init__.cpython-311.opt-1.pyc
│   ├── __init__.cpython-311.opt-2.pyc
│   └── __init__.cpython-311.pyc
└── mpi.so

2 directories, 5 files
```
and in order for `__init__.py` to import the CPython module, you need to use PEP328-style absolute imports on modern python installations.