### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,40 @@
+# Copyright René Ferdinand Rivera Morell 2024
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/mpi
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/config//boost_config
+        <source>/boost/core//boost_core
+        <source>/boost/foreach//boost_foreach
+        <source>/boost/function//boost_function
+        <source>/boost/graph//boost_graph
+        <source>/boost/integer//boost_integer
+        <source>/boost/iterator//boost_iterator
+        <source>/boost/lexical_cast//boost_lexical_cast
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/optional//boost_optional
+        <source>/boost/python//boost_python
+        <source>/boost/serialization//boost_serialization
+        <source>/boost/smart_ptr//boost_smart_ptr
+        <source>/boost/static_assert//boost_static_assert
+        <source>/boost/throw_exception//boost_throw_exception
+        <source>/boost/type_traits//boost_type_traits
+        <source>/boost/utility//boost_utility
+        <include>include
+    ;
+
+explicit
+    [ alias boost_mpi : build//boost_mpi ]
+    [ alias boost_mpi_python : build//boost_mpi_python ]
+    [ alias mpi : build//mpi ]
+    [ alias all : boost_mpi boost_mpi_python mpi test ]
+    ;
+
+call-if : boost-library mpi
+    : install boost_mpi boost_mpi_python mpi
+    ;

--- a/build.jam
+++ b/build.jam
@@ -5,26 +5,28 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/assert//boost_assert
+    /boost/config//boost_config
+    /boost/core//boost_core
+    /boost/foreach//boost_foreach
+    /boost/function//boost_function
+    /boost/graph//boost_graph
+    /boost/integer//boost_integer
+    /boost/iterator//boost_iterator
+    /boost/lexical_cast//boost_lexical_cast
+    /boost/mpl//boost_mpl
+    /boost/optional//boost_optional
+    /boost/python//boost_python
+    /boost/serialization//boost_serialization
+    /boost/smart_ptr//boost_smart_ptr
+    /boost/static_assert//boost_static_assert
+    /boost/throw_exception//boost_throw_exception
+    /boost/type_traits//boost_type_traits
+    /boost/utility//boost_utility ;
+
 project /boost/mpi
     : common-requirements
-        <library>/boost/assert//boost_assert
-        <library>/boost/config//boost_config
-        <library>/boost/core//boost_core
-        <library>/boost/foreach//boost_foreach
-        <library>/boost/function//boost_function
-        <library>/boost/graph//boost_graph
-        <library>/boost/integer//boost_integer
-        <library>/boost/iterator//boost_iterator
-        <library>/boost/lexical_cast//boost_lexical_cast
-        <library>/boost/mpl//boost_mpl
-        <library>/boost/optional//boost_optional
-        <library>/boost/python//boost_python
-        <library>/boost/serialization//boost_serialization
-        <library>/boost/smart_ptr//boost_smart_ptr
-        <library>/boost/static_assert//boost_static_assert
-        <library>/boost/throw_exception//boost_throw_exception
-        <library>/boost/type_traits//boost_type_traits
-        <library>/boost/utility//boost_utility
         <include>include
     ;
 
@@ -38,3 +40,4 @@ explicit
 call-if : boost-library mpi
     : install boost_mpi boost_mpi_python mpi
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -22,8 +22,7 @@ constant boost_dependencies :
     /boost/smart_ptr//boost_smart_ptr
     /boost/static_assert//boost_static_assert
     /boost/throw_exception//boost_throw_exception
-    /boost/type_traits//boost_type_traits
-    /boost/utility//boost_utility ;
+    /boost/type_traits//boost_type_traits ;
 
 project /boost/mpi
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/mpi
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -7,24 +7,24 @@ import project ;
 
 project /boost/mpi
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/config//boost_config
-        <source>/boost/core//boost_core
-        <source>/boost/foreach//boost_foreach
-        <source>/boost/function//boost_function
-        <source>/boost/graph//boost_graph
-        <source>/boost/integer//boost_integer
-        <source>/boost/iterator//boost_iterator
-        <source>/boost/lexical_cast//boost_lexical_cast
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/optional//boost_optional
-        <source>/boost/python//boost_python
-        <source>/boost/serialization//boost_serialization
-        <source>/boost/smart_ptr//boost_smart_ptr
-        <source>/boost/static_assert//boost_static_assert
-        <source>/boost/throw_exception//boost_throw_exception
-        <source>/boost/type_traits//boost_type_traits
-        <source>/boost/utility//boost_utility
+        <library>/boost/assert//boost_assert
+        <library>/boost/config//boost_config
+        <library>/boost/core//boost_core
+        <library>/boost/foreach//boost_foreach
+        <library>/boost/function//boost_function
+        <library>/boost/graph//boost_graph
+        <library>/boost/integer//boost_integer
+        <library>/boost/iterator//boost_iterator
+        <library>/boost/lexical_cast//boost_lexical_cast
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/optional//boost_optional
+        <library>/boost/python//boost_python
+        <library>/boost/serialization//boost_serialization
+        <library>/boost/smart_ptr//boost_smart_ptr
+        <library>/boost/static_assert//boost_static_assert
+        <library>/boost/throw_exception//boost_throw_exception
+        <library>/boost/type_traits//boost_type_traits
+        <library>/boost/utility//boost_utility
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/mpi

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -15,19 +15,18 @@ import python ;
 import option ;
 import regex ;
 
-#
-# The `version-suffix` rule really belongs into python.jam, and
-# should be moved there. `split-version` is only duplicated here
-# as a prerequisite. (See https://github.com/boostorg/build/pull/290)
-#
-
-
-mpi_python_libs = ;
+rule tag ( name : type ? : property-set )
+{
+    if python-tag in [ RULENAMES $(__name__) ]
+    {
+        return [  $(__name__).python-tag $(name) : $(type) : $(property-set) ] ;
+    }
+}
 
 if [ mpi.configured ]
 {
 
-project boost/mpi
+project
   : source-location ../src
   ;
 
@@ -57,7 +56,7 @@ lib boost_mpi
     text_skeleton_oarchive.cpp
     timer.cpp
   : # Requirements
-    <library>../../serialization/build//boost_serialization
+    <library>/boost/serialization//boost_serialization
     <library>/mpi//mpi [ mpi.extra-requirements ]
     <define>BOOST_MPI_SOURCE=1
     <link>shared:<define>BOOST_MPI_DYN_LINK=1
@@ -65,12 +64,12 @@ lib boost_mpi
   : # Default build
     <link>shared
   : # Usage requirements
-    <library>../../serialization/build//boost_serialization
+    <library>/boost/serialization//boost_serialization
     <library>/mpi//mpi [ mpi.extra-requirements ]
   ;
 
-  if [ python.configured ]
-  {
+    if [ python.configured ]
+    {
             lib boost_mpi_python
               : # Sources
                 python/serialize.cpp
@@ -84,8 +83,8 @@ lib boost_mpi
                 <link>shared:<define>BOOST_PYTHON_DYN_LINK=1
                 <define>BOOST_MPI_PYTHON_SOURCE=1
                 <python-debugging>on:<define>BOOST_DEBUG_PYTHON
-                -<tag>@$(BOOST_JAMROOT_MODULE)%$(BOOST_JAMROOT_MODULE).tag
-                <tag>@python-tag
+                -<tag>@%boostcpp.tag
+                <tag>@tag
                 <conditional>@python.require-py
                 <local-visibility>global
 
@@ -93,6 +92,7 @@ lib boost_mpi
                 <link>shared
               : # Usage requirements
                 <library>/mpi//mpi [ mpi.extra-requirements ]
+                <library>/python//python
               ;
 
             python-extension mpi
@@ -120,22 +120,25 @@ lib boost_mpi
                 <link>shared <runtime-link>shared
                 <python-debugging>on:<define>BOOST_DEBUG_PYTHON
               ;
-
-            mpi_python_libs = boost_mpi_python mpi ;
-  }
-}
-else if ! ( --without-mpi in  [ modules.peek : ARGV ] )
-{
-  message boost_mpi   
-      : "warning: skipping optional Message Passing Interface (MPI) library."
-      : "note: to enable MPI support, add \"using mpi ;\" to user-config.jam."
-      : "note: to suppress this message, pass \"--without-mpi\" to bjam."
-      : "note: otherwise, you can safely ignore this message." 
-      ;
+    }
+    else
+    {
+        alias boost_mpi_python ;
+        alias mpi ;
+    }
 }
 else
 {
-  alias boost_mpi ;
+    if ! ( --without-mpi in  [ modules.peek : ARGV ] )
+    {
+        message boost_mpi
+            : "warning: skipping optional Message Passing Interface (MPI) library."
+            : "note: to enable MPI support, add \"using mpi ;\" to user-config.jam."
+            : "note: to suppress this message, pass \"--without-mpi\" to b2."
+            : "note: otherwise, you can safely ignore this message." 
+            ;
+    }
+    alias boost_mpi_python ;
+    alias mpi ;
+    alias boost_mpi ;
 }
-
-boost-install boost_mpi $(mpi_python_libs) ;

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -28,6 +28,7 @@ if [ mpi.configured ]
 
 project
   : source-location ../src
+  : common-requirements <library>$(boost_dependencies)
   ;
 
 lib boost_mpi

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -84,6 +84,7 @@ lib boost_mpi
                 <define>BOOST_MPI_PYTHON_SOURCE=1
                 <python-debugging>on:<define>BOOST_DEBUG_PYTHON
                 -<tag>@%boostcpp.tag
+                -<tag>@$(BOOST_JAMROOT_MODULE)%$(BOOST_JAMROOT_MODULE).tag
                 <tag>@tag
                 <conditional>@python.require-py
                 <local-visibility>global

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -23,12 +23,17 @@ rule tag ( name : type ? : property-set )
     }
 }
 
+constant boost_dependencies_private :
+    /boost/utility//boost_utility
+    ;
+
 if [ mpi.configured ]
 {
 
 project
   : source-location ../src
   : common-requirements <library>$(boost_dependencies)
+  : requirements <library>$(boost_dependencies_private)
   ;
 
 lib boost_mpi

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -66,6 +66,7 @@ lib boost_mpi
   : # Usage requirements
     <library>/boost/serialization//boost_serialization
     <library>/mpi//mpi [ mpi.extra-requirements ]
+    <define>BOOST_MPI_NO_LIB=1
   ;
 
     if [ python.configured ]
@@ -94,6 +95,7 @@ lib boost_mpi
               : # Usage requirements
                 <library>/mpi//mpi [ mpi.extra-requirements ]
                 <library>/python//python
+                <define>BOOST_MPI_PYTHON_NO_LIB=1
               ;
 
             python-extension mpi
@@ -136,7 +138,7 @@ else
             : "warning: skipping optional Message Passing Interface (MPI) library."
             : "note: to enable MPI support, add \"using mpi ;\" to user-config.jam."
             : "note: to suppress this message, pass \"--without-mpi\" to b2."
-            : "note: otherwise, you can safely ignore this message." 
+            : "note: otherwise, you can safely ignore this message."
             ;
     }
     alias boost_mpi_python ;

--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -1,6 +1,6 @@
 # Copyright (C) 2005-2006 Douglas Gregor <doug.gregor@gmail.com>
 #
-# Distributed under the Boost Software License, Version 1.0. (See accompanying 
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt.)
 project boost/mpi/doc ;
 
@@ -8,33 +8,33 @@ using quickbook ;
 using boostbook ;
 using doxygen ;
 
-doxygen mpi_autodoc 
+doxygen mpi_autodoc
   : [ glob
-    ../../../boost/mpi.hpp
-    ../../../boost/mpi/allocator.hpp
-    ../../../boost/mpi/cartesian_communicator.hpp
-    ../../../boost/mpi/collectives.hpp
-    ../../../boost/mpi/collectives_fwd.hpp
-    ../../../boost/mpi/communicator.hpp
-    ../../../boost/mpi/config.hpp
-    ../../../boost/mpi/datatype.hpp
-    ../../../boost/mpi/datatype_fwd.hpp
-    ../../../boost/mpi/environment.hpp
-    ../../../boost/mpi/exception.hpp
-    ../../../boost/mpi/graph_communicator.hpp
-    ../../../boost/mpi/group.hpp
-    ../../../boost/mpi/intercommunicator.hpp
-    ../../../boost/mpi/nonblocking.hpp
-    ../../../boost/mpi/operations.hpp
-    ../../../boost/mpi/packed_iarchive.hpp
-    ../../../boost/mpi/packed_oarchive.hpp
-    ../../../boost/mpi/skeleton_and_content.hpp
-    ../../../boost/mpi/skeleton_and_content_fwd.hpp
-    ../../../boost/mpi/status.hpp
-    ../../../boost/mpi/request.hpp
-    ../../../boost/mpi/timer.hpp
-    ../../../boost/mpi/inplace.hpp
-    ../../../boost/mpi/python.hpp
+    ../include/boost/mpi.hpp
+    ../include/boost/mpi/allocator.hpp
+    ../include/boost/mpi/cartesian_communicator.hpp
+    ../include/boost/mpi/collectives.hpp
+    ../include/boost/mpi/collectives_fwd.hpp
+    ../include/boost/mpi/communicator.hpp
+    ../include/boost/mpi/config.hpp
+    ../include/boost/mpi/datatype.hpp
+    ../include/boost/mpi/datatype_fwd.hpp
+    ../include/boost/mpi/environment.hpp
+    ../include/boost/mpi/exception.hpp
+    ../include/boost/mpi/graph_communicator.hpp
+    ../include/boost/mpi/group.hpp
+    ../include/boost/mpi/intercommunicator.hpp
+    ../include/boost/mpi/nonblocking.hpp
+    ../include/boost/mpi/operations.hpp
+    ../include/boost/mpi/packed_iarchive.hpp
+    ../include/boost/mpi/packed_oarchive.hpp
+    ../include/boost/mpi/skeleton_and_content.hpp
+    ../include/boost/mpi/skeleton_and_content_fwd.hpp
+    ../include/boost/mpi/status.hpp
+    ../include/boost/mpi/request.hpp
+    ../include/boost/mpi/timer.hpp
+    ../include/boost/mpi/inplace.hpp
+    ../include/boost/mpi/python.hpp
     ]
   : <doxygen:param>MACRO_EXPANSION=YES
     <doxygen:param>EXPAND_ONLY_PREDEF=YES
@@ -43,7 +43,7 @@ doxygen mpi_autodoc
 
 xml mpi : mpi.qbk ;
 
-boostbook standalone : mpi mpi_autodoc 
+boostbook standalone : mpi mpi_autodoc
               :
               <xsl:param>boost.root=../../../..
               <format>pdf:<xsl:param>max-columns=66

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -12,7 +12,7 @@
 import mpi : mpi-test ;
 
 project : requirements
-    <library>/boost/test//boost_test
+    <library>/boost/test//included
     <library>/boost/mpi//boost_mpi
     <library>/boost/mpi//boost_mpi_python
     <mpi.run-flags>--oversubscribe

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -9,8 +9,14 @@
 # Authors: Douglas Gregor
 #          Andrew Lumsdaine
 
-project : requirements <library>/boost//mpi ;
 import mpi : mpi-test ;
+
+project : requirements
+    <source>/boost/test//boost_test
+    <source>/boost/mpi//boost_mpi
+    <source>/boost/mpi//boost_mpi_python
+    <mpi.run-flags>--oversubscribe
+    ;
 
 if [ mpi.configured ]
 {

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -3,7 +3,7 @@
 # (C) Copyright 2005, 2006 Trustees of Indiana University
 # (C) Copyright 2005 Douglas Gregor
 #
-# Distributed under the Boost Software License, Version 1.0. (See accompanying 
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt.)
 #
 # Authors: Douglas Gregor
@@ -12,9 +12,9 @@
 import mpi : mpi-test ;
 
 project : requirements
-    <source>/boost/test//boost_test
-    <source>/boost/mpi//boost_mpi
-    <source>/boost/mpi//boost_mpi_python
+    <library>/boost/test//boost_test
+    <library>/boost/mpi//boost_mpi
+    <library>/boost/mpi//boost_mpi_python
     <mpi.run-flags>--oversubscribe
     ;
 


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.