### PR TITLE
Use CMake's MPI_CXX_SKIP_MPICXX to add definitions to disable MPI 2.0's CXX…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,8 +62,9 @@ target_link_libraries(boost_mpi
 
 if(BOOST_ENABLE_MPI)
 
-  find_package(MPI REQUIRED COMPONENTS C)
-  target_link_libraries(boost_mpi PUBLIC MPI::MPI_C)
+  set(MPI_CXX_SKIP_MPICXX ON)
+  find_package(MPI REQUIRED COMPONENTS CXX)
+  target_link_libraries(boost_mpi PUBLIC MPI::MPI_CXX)
 
 endif()
 

--- a/include/boost/mpi/config.hpp
+++ b/include/boost/mpi/config.hpp
@@ -13,12 +13,6 @@
 #ifndef BOOST_MPI_CONFIG_HPP
 #define BOOST_MPI_CONFIG_HPP
 
-/* Force MPICH not to define SEEK_SET, SEEK_CUR, and SEEK_END, which
-   conflict with the versions in <stdio.h> and <cstdio>. */
-#define MPICH_IGNORE_CXX_SEEK 1
-/* We do not want to link in the OpenMPI CXX stuff */
-#define OMPI_SKIP_MPICXX
-
 #include <mpi.h>
 #include <boost/config.hpp>
 


### PR DESCRIPTION
# Original problem

Currently, boost_mpi links to `MPI::MPI_C` target and use 

```cpp
/* Force MPICH not to define SEEK_SET, SEEK_CUR, and SEEK_END, which
   conflict with the versions in <stdio.h> and <cstdio>. */
#define MPICH_IGNORE_CXX_SEEK 1
/* We do not want to link in the OpenMPI CXX stuff */
#define OMPI_SKIP_MPICXX
```

to disable OpenMPI and MPICH's deprecated MPICXX binding. However, if user write code like this:

```cpp
#include <mpi.h>
#include <boost/mpi.hpp>
```

these macro won't be able to disable the MPI's CXX binding, and symbols leaks to the translation units, cause really weired link error in my machine:

```console
undefined references to `MPI::Comm::Comm()'
```

# Fix

After reading the CMake's [FindMPI documentation](https://cmake.org/cmake/help/latest/module/FindMPI.html) and reading the `FindMPI.cmake` (especially [this line](https://github.com/Kitware/CMake/blob/82dafe874ec9a38c443bb1517fd58eb2c7c82a7e/Modules/FindMPI.cmake#L1118C52-L1118C69)) I believe the correct way to link a CPP binary object to MPI's C library is:

```cmake
set(MPI_CXX_SKIP_MPICXX ON)
find_package(MPI REQUIRED COMPONENTS CXX)
target_link_libraries(boost_mpi PUBLIC MPI::MPI_CXX)
```

In this way, CMake will add `MPICH_SKIP_MPICXX`, `OMPI_SKIP_MPICXX` and `_MPICC_H` definitions so cxx binding headers can be reliably and portably disabled.
