### PR TITLE
Remove boost_python from global dependency list

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -17,7 +17,6 @@ constant boost_dependencies :
     /boost/lexical_cast//boost_lexical_cast
     /boost/mpl//boost_mpl
     /boost/optional//boost_optional
-    /boost/python//boost_python
     /boost/serialization//boost_serialization
     /boost/smart_ptr//boost_smart_ptr
     /boost/static_assert//boost_static_assert


### PR DESCRIPTION
Closes https://github.com/boostorg/mpi/issues/161