### PR TITLE
Associate primitive bool type with MPI_CXX_BOOL and make it a logical…

### DIFF
--- a/include/boost/mpi/datatype.hpp
+++ b/include/boost/mpi/datatype.hpp
@@ -213,6 +213,10 @@ BOOST_MPI_DATATYPE(packed, MPI_PACKED, builtin);
 BOOST_MPI_DATATYPE(char, MPI_CHAR, builtin);
 
 /// INTERNAL ONLY
+/// We need to pick a boolean type, MPI_CXX_BOOL seems appropriate
+BOOST_MPI_DATATYPE(bool, MPI_CXX_BOOL, logical);
+
+/// INTERNAL ONLY
 BOOST_MPI_DATATYPE(short, MPI_SHORT, integer);
 
 /// INTERNAL ONLY
@@ -316,33 +320,6 @@ BOOST_MPI_DATATYPE(signed char, MPI_SIGNED_CHAR, builtin);
 
 
 #endif // Doxygen
-
-namespace detail {
-  inline MPI_Datatype build_mpi_datatype_for_bool()
-  {
-    // this is explicitly freed in mpi_datatype_map::clear
-    MPI_Datatype type;
-    MPI_Type_contiguous(sizeof(bool), MPI_BYTE, &type);
-    MPI_Type_commit(&type);
-    return type;
-  }
-}
-
-/// Support for bool. There is no corresponding MPI_BOOL.
-/// INTERNAL ONLY
-template<>
-inline MPI_Datatype get_mpi_datatype<bool>(const bool&)
-{
-  static MPI_Datatype type = detail::build_mpi_datatype_for_bool();
-  return type;
-}
-
-/// INTERNAL ONLY
-template<>
-struct is_mpi_datatype<bool>
-  : boost::mpl::bool_<true>
-{};
-
 
 #ifndef BOOST_MPI_DOXYGEN
 // direct support for special primitive data types of the serialization library

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,7 +35,7 @@ add_mpi_tests(test_mt_level 1 )
  add_mpi_tests(test_mt_init 1 4 )
 # # # Note: Microsoft MPI fails nonblocking_test on 1 processor
 add_mpi_tests(test_nonblocking 2 11 24 )
-add_mpi_tests(test_reduce 1 )
+add_mpi_tests(test_reduce 1 2 7)
 add_mpi_tests(test_ring 2 3 4 7 8 13 17 )
 add_mpi_tests(test_sendrecv 1 4 7 48 )
 add_mpi_tests(test_wait_any 1 4 7 20 )

--- a/test/test_reduce.cpp
+++ b/test/test_reduce.cpp
@@ -123,6 +123,19 @@ struct int_generator
   int base;
 };
 
+// Generates bools to test with reduce()
+struct bool_generator
+{
+  typedef bool result_type;
+
+  bool_generator(int nbtrue = 0) : nb_true(nbtrue) { }
+  
+  int operator()(int p) const { return p < nb_true; }
+
+ private:
+  int nb_true;
+};
+
 // Generate points to test with reduce()
 struct point_generator
 {
@@ -219,7 +232,9 @@ int main()
                                "maximum", 0), failed);
   BOOST_MPI_COUNT_FAILED(reduce_test(comm, int_generator(), "integers", minimum<int>(),
                                "minimum", 2), failed);
-
+  BOOST_MPI_COUNT_FAILED(reduce_test(comm, bool_generator(), "bools", std::logical_or<bool>(), "logical_or", 0), failed);
+  BOOST_MPI_COUNT_FAILED(reduce_test(comm, bool_generator(), "bools", std::logical_and<bool>(), "logical_and", 0), failed);
+  
   // User-defined MPI datatypes with operations that have the
   // same name as built-in operations.
   BOOST_MPI_COUNT_FAILED(reduce_test(comm, point_generator(point(0,0,0)), "points",


### PR DESCRIPTION
… type so that reduce uses directly MPI_LAND and MPI_LOR.