### PR TITLE
Revert "Make sure we free the Boost.MPI type built for C++ bool" 

### DIFF
--- a/src/mpi_datatype_cache.cpp
+++ b/src/mpi_datatype_cache.cpp
@@ -8,7 +8,6 @@
 
 #include <boost/archive/detail/archive_serializer_map.hpp>
 #include <boost/mpi/detail/mpi_datatype_cache.hpp>
-#include <boost/mpi/datatype.hpp>
 #include <map>
 
 namespace boost { namespace mpi { namespace detail {
@@ -35,9 +34,6 @@ namespace boost { namespace mpi { namespace detail {
       // ignore errors in the destructor
       for (stored_map_type::iterator it=impl->map.begin(); it != impl->map.end(); ++it)
         MPI_Type_free(&(it->second));
-      // We explicitly created this one, as there is no equivalent in the MPI standard
-      MPI_Datatype bool_type = get_mpi_datatype(bool());
-      MPI_Type_free(&bool_type);
     }
   }
   


### PR DESCRIPTION
... "(sice there is no MPI Bool type)"

This reverts commit c5270b066f6f810b2fa184650a4215bb5c83ba27.

Since #163 "Associate primitive bool type with MPI_CXX_BOOL and make it a logical… " was merged, a dedicated data type for MPI Bool is no longer registered. So it should no longer be freed, either. Otherwise, crashes would occur during MPI_Finalize.