### PR TITLE
fix "ambiguous target" build system error

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -147,7 +147,6 @@ else
             : "note: otherwise, you can safely ignore this message."
             ;
     }
-    alias boost_mpi_python ;
-    alias mpi ;
-    alias boost_mpi ;
+    alias boost_mpi_python : boost_mpi ;
+    alias mpi : boost_mpi ;
 }


### PR DESCRIPTION
The `message` rule is declaring a target on its own. `alias boost_mpi` was declaring it a second time, hence the ambiguity.

I also added depdency on `boost_mpi` to `boost_mpi_python` and `mpi` in order for the warning to be printed if only those secondary libraries are requested.