### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,6 @@ target_link_libraries(boost_mpi
     Boost::optional
     Boost::serialization
     Boost::smart_ptr
-    Boost::static_assert
     Boost::throw_exception
     Boost::type_traits
 

--- a/build.jam
+++ b/build.jam
@@ -19,7 +19,6 @@ constant boost_dependencies :
     /boost/optional//boost_optional
     /boost/serialization//boost_serialization
     /boost/smart_ptr//boost_smart_ptr
-    /boost/static_assert//boost_static_assert
     /boost/throw_exception//boost_throw_exception
     /boost/type_traits//boost_type_traits ;
 


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.